### PR TITLE
Automat statemachine + refactoring

### DIFF
--- a/docs/server-statemachine.dot
+++ b/docs/server-statemachine.dot
@@ -1,0 +1,22 @@
+/**
+. thinking about state-machine from "hand-drawn" perspective
+. will it look the same as an Automat one?
+**/
+
+digraph {
+        listening -> wait_relay [label="connection_made"]
+
+        wait_relay -> wait_partner [label="please_relay\nFindPartner"]
+        wait_relay -> wait_partner [label="please_relay_for_side\nFindPartner"]
+        wait_relay -> done [label="invalid_token\nSend('bad handshake')\nDisconnect"]
+        wait_relay -> done [label="connection_lost"]
+
+        wait_partner -> relaying [label="got_partner\nConnectPartner(partner)\nSend('ok')"]
+        wait_partner -> done [label="got_bytes\nDisconnect"]
+        wait_partner -> done [label="connection_lost"]
+
+        relaying -> relaying [label="got_bytes\nSend(bytes)"]
+        relaying -> done [label="partner_connection_lost\nDisconnectMe"]
+        relaying -> done [label="connection_lost\nDisconnectPartner"]
+}
+

--- a/src/wormhole_transit_relay/server_state.py
+++ b/src/wormhole_transit_relay/server_state.py
@@ -519,7 +519,7 @@ class TransitServerState(object):
     relaying.upon(
         got_bytes,
         enter=relaying,
-        outputs=[_send_to_partner],
+        outputs=[_count_bytes, _send_to_partner],
     )
     relaying.upon(
         connection_lost,

--- a/src/wormhole_transit_relay/server_state.py
+++ b/src/wormhole_transit_relay/server_state.py
@@ -362,6 +362,10 @@ class TransitServerState(object):
     # some outputs to record "usage" information ..
     @_machine.output()
     def _record_usage(self):
+        if self._mood == "jilted":
+            if self._buddy:
+                if self._buddy._mood == "happy":
+                    return
         self._usage.record(
             started=self._client.started_time,
             buddy_started=self._buddy._client.started_time if self._buddy is not None else None,

--- a/src/wormhole_transit_relay/server_state.py
+++ b/src/wormhole_transit_relay/server_state.py
@@ -572,17 +572,6 @@ class TransitServerState(object):
         else:
             self._mood = "jilted"
 
-    @_machine.output()
-    def _mood_happy_if_second(self):
-        """
-        We disconnected second so we're only happy if we also connected
-        second.
-        """
-        if self._first:
-            self._mood = "jilted"
-        else:
-            self._mood = "happy"
-
     def _real_register_token_for_side(self, token, side):
         """
         A client has connected and sent a valid version 1 or version 2
@@ -692,11 +681,6 @@ class TransitServerState(object):
         enter=done,
         outputs=[_mood_happy_if_first, _disconnect_partner, _unregister, _record_usage],
     )
-#    relaying.upon(
-#        partner_connection_lost,
-#        enter=done,
-#        outputs=[_mood_happy_if_second, _disconnect, _unregister],  # no _record_usage; other side will
-#    )
 
     done.upon(
         connection_lost,

--- a/src/wormhole_transit_relay/server_state.py
+++ b/src/wormhole_transit_relay/server_state.py
@@ -153,8 +153,14 @@ class PendingRequests(object):
         self._active = active_connections
 
     def unregister(self, token, side, tc):
+        """
+        We no longer care about a particular client (e.g. it has
+        disconnected).
+        """
         if token in self._requests:
             self._requests[token].discard((side, tc))
+            if not self._requests[token]:
+                del self._requests[token]
         self._active.unregister(tc)
 
     def register_token(self, token, new_side, new_tc):

--- a/src/wormhole_transit_relay/server_state.py
+++ b/src/wormhole_transit_relay/server_state.py
@@ -161,6 +161,7 @@ class TransitServerState(object):
     _side = None
     _first = None
     _mood = "empty"
+    _total_sent = 0
 
     def __init__(self, pending_requests):
         self._pending_requests = pending_requests
@@ -273,6 +274,10 @@ class TransitServerState(object):
     @_machine.output()
     def _send_impatient(self):
         self._client.send(b"impatient\n")
+
+    @_machine.output()
+    def _count_bytes(self, data):
+        self._total_sent += len(data)
 
     @_machine.output()
     def _send(self, data):
@@ -404,7 +409,7 @@ class TransitServerState(object):
     wait_relay.upon(
         got_bytes,
         enter=done,
-        outputs=[_mood_errory, _disconnect],
+        outputs=[_count_bytes, _mood_errory, _disconnect],
     )
     wait_relay.upon(
         connection_lost,

--- a/src/wormhole_transit_relay/server_state.py
+++ b/src/wormhole_transit_relay/server_state.py
@@ -8,6 +8,7 @@ from zope.interface import (
     Attribute,
     implementer,
 )
+from twisted.python import log
 from .database import get_db
 
 
@@ -170,6 +171,11 @@ class UsageTracker(object):
         """
         self._backends = set()
         self._blur_usage = blur_usage
+        if blur_usage:
+            log.msg("blurring access times to %d seconds" % self._blur_usage)
+## XXX            log.msg("not logging Transit connections to Twisted log")
+        else:
+            log.msg("not blurring access times")
 
     def add_backend(self, backend):
         """

--- a/src/wormhole_transit_relay/server_state.py
+++ b/src/wormhole_transit_relay/server_state.py
@@ -214,14 +214,6 @@ class UsageTracker(object):
         """
         self._backends.add(backend)
 
-    def remove_backend(self, backend):
-        """
-        Remove an existing backend
-
-        :param IUsageWriter backend: the backend to remove
-        """
-        self._backends.remove(backend)
-
     def record(self, started, buddy_started, result, bytes_sent, buddy_bytes):
         """
         :param int started: timestamp when our connection started

--- a/src/wormhole_transit_relay/server_state.py
+++ b/src/wormhole_transit_relay/server_state.py
@@ -407,12 +407,6 @@ class TransitServerState(object):
             d += "-<unsided>"
         return d
 
-    def get_mood(self):
-        """
-        :returns str: description of the current 'mood' of the connection
-        """
-        return self._mood
-
     @_machine.input()
     def connection_made(self, client):
         """

--- a/src/wormhole_transit_relay/server_state.py
+++ b/src/wormhole_transit_relay/server_state.py
@@ -9,7 +9,6 @@ from zope.interface import (
     implementer,
 )
 from twisted.python import log
-from .database import get_db
 
 
 class ITransitClient(Interface):

--- a/src/wormhole_transit_relay/server_state.py
+++ b/src/wormhole_transit_relay/server_state.py
@@ -1,0 +1,299 @@
+
+import automat
+from zope.interface import (
+    Interface,
+    implementer,
+)
+
+
+class ITransitClient(Interface):
+    def send(data):
+        """
+        Send some byets to the client
+        """
+
+    def disconnect(reason):
+        """
+        Disconnect the client transport
+        """
+
+    def connect_partner(other):
+        """
+        Hook up to our partner.
+        :param ITransitClient other: our partner
+        """
+
+    def disconnect_partner():
+        """
+        Disconnect our partner's transport
+        """
+
+
+@implementer(ITransitClient)
+class TestClient(object):
+    _partner = None
+    _data = b""
+
+    def send_to_partner(self, data):
+        print("{} GOT:{}".format(id(self), repr(data)))
+        if self._partner:
+            self._partner.send(data)
+
+    def send(self, data):
+        print("{} SEND:{}".format(id(self), repr(data)))
+        self._data += data
+
+    def disconnect(self):
+        print("disconnect")
+
+    def connect_partner(self, other):
+        print("connect_partner: {} <--> {}".format(id(self), id(other)))
+        assert self._partner is None, "double partner"
+        self._partner = other
+
+    def disconnect_partner(self):
+        assert self._partner is not None, "no partner"
+        print("disconnect_partner: {}".format(id(self._partner)))
+
+
+class PendingRequests(object):
+    """
+    Tracks the tokens we have received from client connections and
+    maps them to their partner connections
+    """
+
+    def register_token(self, *args):
+        """
+        """
+
+
+class TransitServer(object):
+    """
+    Encapsulates the state-machine of the server side of a transit
+    relay connection.
+
+    Once the protocol has been told to relay (or to relay for a side)
+    it starts passing all received bytes to the other side until it
+    closes.
+    """
+
+    _machine = automat.MethodicalMachine()
+    _client = None
+
+    @_machine.input()
+    def connection_made(self, client):
+        """
+        A client has connected. May only be called once.
+
+        :param ITransitClient client: our client.
+        """
+        # NB: the "only called once" is enforced by the state-machine;
+        # this input is only valid for the "listening" state, to which
+        # we never return.
+
+    @_machine.input()
+    def please_relay(self, token):
+        pass
+
+    @_machine.input()
+    def please_relay_for_side(self, token, side):
+        pass
+
+    @_machine.input()
+    def bad_token(self):
+        """
+        A bad token / relay line was received
+        """
+
+    @_machine.input()
+    def got_partner(self, client):
+        """
+        The partner for this relay session has been found
+        """
+
+    @_machine.input()
+    def connection_lost(self):
+        pass
+
+    @_machine.input()
+    def partner_connection_lost(self):
+        pass
+
+    @_machine.input()
+    def got_bytes(self, data):
+        """
+        Some bytes have arrived (that aren't part of the handshake)
+        """
+
+    @_machine.output()
+    def _remember_client(self, client):
+        self._client = client
+
+    @_machine.output()
+    def _register_token(self, token):
+        return self._real_register_token_for_side(token, None)
+
+    @_machine.output()
+    def _register_token_for_side(self, token, side):
+        return self._real_register_token_for_side(token, side)
+
+    @_machine.output()
+    def _unregister(self):
+        """
+        remove us from the thing that remembers tokens and sides
+        """
+
+    @_machine.output()
+    def _send_bad(self):
+        self._client.send("bad handshake\n")
+
+    @_machine.output()
+    def _send_ok(self):
+        self._client.send("ok\n")
+
+    @_machine.output()
+    def _send(self, data):
+        self._client.send(data)
+
+    @_machine.output()
+    def _send_to_partner(self, data):
+        self._client.send_to_partner(data)
+
+    @_machine.output()
+    def _connect_partner(self, client):
+        self._client.connect_partner(client)
+
+    @_machine.output()
+    def _disconnect(self):
+        self._client.disconnect()
+
+    @_machine.output()
+    def _disconnect_partner(self):
+        self._client.disconnect_partner()
+
+    def _real_register_token_for_side(self, token, side):
+        """
+        basically, _got_handshake() + connection_got_token() from "real"
+        code ...and if this is the "second" side, hook them up and
+        pass .got_partner() input to both
+        """
+
+    @_machine.state(initial=True)
+    def listening(self):
+        """
+        Initial state, awaiting connection.
+        """
+
+    @_machine.state()
+    def wait_relay(self):
+        """
+        Waiting for a 'relay' message
+        """
+
+    @_machine.state()
+    def wait_partner(self):
+        """
+        Waiting for our partner to connect
+        """
+
+    @_machine.state()
+    def relaying(self):
+        """
+        Relaying bytes to our partner
+        """
+
+    @_machine.state()
+    def done(self):
+        """
+        Terminal state
+        """
+
+    listening.upon(
+        connection_made,
+        enter=wait_relay,
+        outputs=[_remember_client],
+    )
+
+    wait_relay.upon(
+        please_relay,
+        enter=wait_partner,
+        outputs=[_register_token],
+    )
+    wait_relay.upon(
+        please_relay_for_side,
+        enter=wait_partner,
+        outputs=[_register_token_for_side],
+    )
+    wait_relay.upon(
+        bad_token,
+        enter=done,
+        outputs=[_send_bad, _disconnect],
+    )
+    wait_relay.upon(
+        connection_lost,
+        enter=done,
+        outputs=[_disconnect],
+    )
+
+    wait_partner.upon(
+        got_partner,
+        enter=relaying,
+        outputs=[_send_ok, _connect_partner],
+    )
+    wait_partner.upon(
+        connection_lost,
+        enter=done,
+        outputs=[_unregister],
+    )
+
+    relaying.upon(
+        got_bytes,
+        enter=relaying,
+        outputs=[_send_to_partner],
+    )
+    relaying.upon(
+        connection_lost,
+        enter=done,
+        outputs=[_disconnect_partner, _unregister],
+    )
+    relaying.upon(
+        partner_connection_lost,
+        enter=done,
+        outputs=[_disconnect, _unregister],
+    )
+
+
+
+
+# actions:
+# - send("ok")
+# - send("bad handshake")
+# - disconnect
+# - ...
+
+if __name__ == "__main__":
+    server0 = TransitServer()
+    client0 =  TestClient()
+    server1 = TransitServer()
+    client1 =  TestClient()
+    server0.connection_made(client0)
+    server0.please_relay(b"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+
+    # this would be an error, because our partner hasn't shown up yet
+    # print(server0.got_bytes(b"asdf"))
+
+    server1.connection_made(client1)
+    server1.please_relay(b"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+
+    # XXX the PendingRequests stuff should do this, going "by hand" for now
+    server0.got_partner(client1)
+    server1.got_partner(client0)
+
+    # should be connected now
+    server0.got_bytes(b"asdf")
+    # client1 should receive b"asdf"
+
+    server0.connection_lost()
+    print("----[ received data on both sides ]----")
+    print("client0:{}".format(repr(client0._data)))
+    print("client1:{}".format(repr(client1._data)))

--- a/src/wormhole_transit_relay/server_state.py
+++ b/src/wormhole_transit_relay/server_state.py
@@ -692,11 +692,11 @@ class TransitServerState(object):
         enter=done,
         outputs=[_mood_happy_if_first, _disconnect_partner, _unregister, _record_usage],
     )
-    relaying.upon(
-        partner_connection_lost,
-        enter=done,
-        outputs=[_mood_happy_if_second, _disconnect, _unregister, _record_usage],
-    )
+#    relaying.upon(
+#        partner_connection_lost,
+#        enter=done,
+#        outputs=[_mood_happy_if_second, _disconnect, _unregister],  # no _record_usage; other side will
+#    )
 
     done.upon(
         connection_lost,

--- a/src/wormhole_transit_relay/server_state.py
+++ b/src/wormhole_transit_relay/server_state.py
@@ -149,13 +149,10 @@ def create_usage_tracker(blur_usage, log_file, usage_db):
     """
     tracker = UsageTracker(blur_usage)
     if usage_db:
-        db = get_db(usage_db)
-        tracker.add_backend(DatabaseUsageRecorder(db))
+        tracker.add_backend(DatabaseUsageRecorder(usage_db))
     if log_file:
         tracker.add_backend(LogFileUsageRecorder(log_file))
     return tracker
-
-
 
 
 class UsageTracker(object):

--- a/src/wormhole_transit_relay/server_state.py
+++ b/src/wormhole_transit_relay/server_state.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 
 import automat
 from zope.interface import (
@@ -12,7 +13,7 @@ class ITransitClient(Interface):
         Send some byets to the client
         """
 
-    def disconnect(reason):
+    def disconnect():
         """
         Disconnect the client transport
         """
@@ -37,7 +38,7 @@ class TestClient(object):
     def send_to_partner(self, data):
         print("{} GOT:{}".format(id(self), repr(data)))
         if self._partner:
-            self._partner.send(data)
+            self._partner._client.send(data)
 
     def send(self, data):
         print("{} SEND:{}".format(id(self), repr(data)))
@@ -56,18 +57,94 @@ class TestClient(object):
         print("disconnect_partner: {}".format(id(self._partner)))
 
 
+class ActiveConnections(object):
+    """
+    Tracks active connections. A connection is 'active' when both
+    sides have shown up and they are glued together.
+    """
+    def __init__(self):
+        self._connections = set()
+
+    def register(self, side0, side1):
+        """
+        A connection has become active so register both its sides
+
+        :param TransitConnection side0: one side of the connection
+        :param TransitConnection side1: one side of the connection
+        """
+        self._connections.add(side0)
+        self._connections.add(side1)
+
+    def unregister(self, side):
+        """
+        One side of a connection has become inactive.
+
+        :param TransitConnection side: an inactive side of a connection
+        """
+        self._connections.discard(side)
+
+
 class PendingRequests(object):
     """
     Tracks the tokens we have received from client connections and
-    maps them to their partner connections
+    maps them to their partner connections for requests that haven't
+    yet been 'glued together' (that is, one side hasn't yet shown up).
     """
 
-    def register_token(self, *args):
+    def __init__(self, active_connections):
+        self._requests = defaultdict(set) # token -> set((side, TransitConnection))
+        self._active = active_connections
+
+    def unregister(self, token, side, tc):
+        if token in self._requests:
+            self._requests[token].discard((side, tc))
+        self._active.unregister(tc)
+
+    def register_token(self, token, new_side, new_tc):
         """
+        A client has connected and successfully offered a token (and
+        optional 'side' token). If this is the first one for this
+        token, we merely remember it. If it is the second side for
+        this token we connect them together.
+
+        :returns bool: True if we are the first side to register this
+            token
         """
+        potentials = self._requests[token]
+        for old in potentials:
+            (old_side, old_tc) = old
+            if ((old_side is None)
+                or (new_side is None)
+                or (old_side != new_side)):
+                # we found a match
+                # FIXME: debug-log this
+                # print("transit relay 2: %s" % new_tc.get_token())
+
+                # drop and stop tracking the rest
+                potentials.remove(old)
+                for (_, leftover_tc) in potentials.copy():
+                    # Don't record this as errory. It's just a spare connection
+                    # from the same side as a connection that got used. This
+                    # can happen if the connection hint contains multiple
+                    # addresses (we don't currently support those, but it'd
+                    # probably be useful in the future).
+                    leftover_tc.disconnect_redundant()
+                self._requests.pop(token, None)
+
+                # glue the two ends together
+                self._active.register(new_tc, old_tc)
+                new_tc.got_partner(old_tc)
+                old_tc.got_partner(new_tc)
+                return False
+
+        # FIXME: debug-log this
+        # print("transit relay 1: %s" % new_tc.get_token())
+        potentials.add((new_side, new_tc))
+        return True
+        # TODO: timer
 
 
-class TransitServer(object):
+class TransitServerState(object):
     """
     Encapsulates the state-machine of the server side of a transit
     relay connection.
@@ -79,6 +156,36 @@ class TransitServer(object):
 
     _machine = automat.MethodicalMachine()
     _client = None
+    _buddy = None
+    _token = None
+    _side = None
+    _first = None
+    _mood = "empty"
+
+    def __init__(self, pending_requests):
+        self._pending_requests = pending_requests
+
+    def get_token(self):
+        """
+        :returns str: a string describing our token. This will be "-" if
+            we have no token yet, or "{16 chars}-<unsided>" if we have
+            just a token or "{16 chars}-{16 chars}" if we have a token and
+            a side.
+        """
+        d = "-"
+        if self._token is not None:
+            d = self._token[:16].decode("ascii")
+        if self._side is not None:
+            d += "-" + self._side.decode("ascii")
+        else:
+            d += "-<unsided>"
+        return d
+
+    def get_mood(self):
+        """
+        :returns str: description of the current 'mood' of the connection
+        """
+        return self._mood
 
     @_machine.input()
     def connection_made(self, client):
@@ -93,16 +200,22 @@ class TransitServer(object):
 
     @_machine.input()
     def please_relay(self, token):
-        pass
+        """
+        A 'please relay X' message has been received (the original version
+        of the protocol).
+        """
 
     @_machine.input()
     def please_relay_for_side(self, token, side):
-        pass
+        """
+        A 'please relay X for side Y' message has been received (the
+        second version of the protocol).
+        """
 
     @_machine.input()
     def bad_token(self):
         """
-        A bad token / relay line was received
+        A bad token / relay line was received (e.g. couldn't be parsed)
         """
 
     @_machine.input()
@@ -113,11 +226,15 @@ class TransitServer(object):
 
     @_machine.input()
     def connection_lost(self):
-        pass
+        """
+        Our transport has failed.
+        """
 
     @_machine.input()
     def partner_connection_lost(self):
-        pass
+        """
+        Our partner's transport has failed.
+        """
 
     @_machine.input()
     def got_bytes(self, data):
@@ -142,14 +259,20 @@ class TransitServer(object):
         """
         remove us from the thing that remembers tokens and sides
         """
+        return self._pending_requests.unregister(self._token, self._side, self)
 
     @_machine.output()
     def _send_bad(self):
-        self._client.send("bad handshake\n")
+        self._mood = "errory"
+        self._client.send(b"bad handshake\n")
 
     @_machine.output()
     def _send_ok(self):
-        self._client.send("ok\n")
+        self._client.send(b"ok\n")
+
+    @_machine.output()
+    def _send_impatient(self):
+        self._client.send(b"impatient\n")
 
     @_machine.output()
     def _send(self, data):
@@ -157,10 +280,11 @@ class TransitServer(object):
 
     @_machine.output()
     def _send_to_partner(self, data):
-        self._client.send_to_partner(data)
+        self._buddy._client.send(data)
 
     @_machine.output()
     def _connect_partner(self, client):
+        self._buddy = client
         self._client.connect_partner(client)
 
     @_machine.output()
@@ -171,12 +295,60 @@ class TransitServer(object):
     def _disconnect_partner(self):
         self._client.disconnect_partner()
 
+    # some outputs to record the "mood" ..
+    @_machine.output()
+    def _mood_happy(self):
+        self._mood = "happy"
+
+    @_machine.output()
+    def _mood_lonely(self):
+        self._mood = "lonely"
+
+    @_machine.output()
+    def _mood_impatient(self):
+        self._mood = "impatient"
+
+    @_machine.output()
+    def _mood_errory(self):
+        self._mood = "errory"
+
+    @_machine.output()
+    def _mood_happy_if_first(self):
+        """
+        We disconnected first so we're only happy if we also connected
+        first.
+        """
+        if self._first:
+            self._mood = "happy"
+        else:
+            self._mood = "jilted"
+
+    @_machine.output()
+    def _mood_happy_if_second(self):
+        """
+        We disconnected second so we're only happy if we also connected
+        second.
+        """
+        if self._first:
+            self._mood = "jilted"
+        else:
+            self._mood = "happy"
+
     def _real_register_token_for_side(self, token, side):
         """
-        basically, _got_handshake() + connection_got_token() from "real"
-        code ...and if this is the "second" side, hook them up and
-        pass .got_partner() input to both
+        A client has connected and sent a valid version 1 or version 2
+        handshake. If the former, `side` will be None.
+
+        In either case, we remember the tokens and register
+        ourselves. This might result in 'got_partner' notifications to
+        two state-machines if this is the second side for a given token.
+
+        :param bytes token: the token
+        :param bytes side: The side token (or None)
         """
+        self._token = token
+        self._side = side
+        self._first = self._pending_requests.register_token(token, side, self)
 
     @_machine.state(initial=True)
     def listening(self):
@@ -217,17 +389,22 @@ class TransitServer(object):
     wait_relay.upon(
         please_relay,
         enter=wait_partner,
-        outputs=[_register_token],
+        outputs=[_mood_lonely, _register_token],
     )
     wait_relay.upon(
         please_relay_for_side,
         enter=wait_partner,
-        outputs=[_register_token_for_side],
+        outputs=[_mood_lonely, _register_token_for_side],
     )
     wait_relay.upon(
         bad_token,
         enter=done,
-        outputs=[_send_bad, _disconnect],
+        outputs=[_mood_errory, _send_bad, _disconnect],
+    )
+    wait_relay.upon(
+        got_bytes,
+        enter=done,
+        outputs=[_mood_errory, _disconnect],
     )
     wait_relay.upon(
         connection_lost,
@@ -238,12 +415,17 @@ class TransitServer(object):
     wait_partner.upon(
         got_partner,
         enter=relaying,
-        outputs=[_send_ok, _connect_partner],
+        outputs=[_mood_happy, _send_ok, _connect_partner],
     )
     wait_partner.upon(
         connection_lost,
         enter=done,
-        outputs=[_unregister],
+        outputs=[_mood_lonely, _unregister],
+    )
+    wait_partner.upon(
+        got_bytes,
+        enter=done,
+        outputs=[_mood_impatient, _send_impatient, _disconnect, _unregister],
     )
 
     relaying.upon(
@@ -254,12 +436,23 @@ class TransitServer(object):
     relaying.upon(
         connection_lost,
         enter=done,
-        outputs=[_disconnect_partner, _unregister],
+        outputs=[_mood_happy_if_first, _disconnect_partner, _unregister],
     )
     relaying.upon(
         partner_connection_lost,
         enter=done,
-        outputs=[_disconnect, _unregister],
+        outputs=[_mood_happy_if_second, _disconnect, _unregister],
+    )
+
+    done.upon(
+        connection_lost,
+        enter=done,
+        outputs=[],
+    )
+    done.upon(
+        partner_connection_lost,
+        enter=done,
+        outputs=[],
     )
 
 
@@ -272,9 +465,12 @@ class TransitServer(object):
 # - ...
 
 if __name__ == "__main__":
-    server0 = TransitServer()
+    active = ActiveConnections()
+    pending = PendingRequests(active)
+
+    server0 = TransitServerState(pending)
     client0 =  TestClient()
-    server1 = TransitServer()
+    server1 = TransitServerState(pending)
     client1 =  TestClient()
     server0.connection_made(client0)
     server0.please_relay(b"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
@@ -282,12 +478,14 @@ if __name__ == "__main__":
     # this would be an error, because our partner hasn't shown up yet
     # print(server0.got_bytes(b"asdf"))
 
+    print("about to relay client1")
     server1.connection_made(client1)
     server1.please_relay(b"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+    print("done")
 
     # XXX the PendingRequests stuff should do this, going "by hand" for now
-    server0.got_partner(client1)
-    server1.got_partner(client0)
+#    server0.got_partner(client1)
+#    server1.got_partner(client0)
 
     # should be connected now
     server0.got_bytes(b"asdf")

--- a/src/wormhole_transit_relay/server_tap.py
+++ b/src/wormhole_transit_relay/server_tap.py
@@ -38,10 +38,11 @@ def makeService(config, reactor=reactor):
         if config["log-fd"] is not None
         else None
     )
+    db = None if config["usage-db"] is None else get_db(config["usage-db"])
     usage = create_usage_tracker(
         blur_usage=config["blur-usage"],
         log_file=log_file,
-        usage_db=config["usage-db"],
+        usage_db=db,
     )
     factory = transit_server.Transit(usage)
     parent = MultiService()

--- a/src/wormhole_transit_relay/server_tap.py
+++ b/src/wormhole_transit_relay/server_tap.py
@@ -44,8 +44,8 @@ def makeService(config, reactor=reactor):
         log_file=log_file,
         usage_db=db,
     )
-    factory = transit_server.Transit(usage)
+    factory = transit_server.Transit(usage, reactor.seconds)
     parent = MultiService()
     StreamServerEndpointService(ep, factory).setServiceParent(parent)
-### FIXME TODO    TimerService(5*60.0, factory.timerUpdateStats).setServiceParent(parent)
+    TimerService(5*60.0, factory.update_stats).setServiceParent(parent)
     return parent

--- a/src/wormhole_transit_relay/server_tap.py
+++ b/src/wormhole_transit_relay/server_tap.py
@@ -8,6 +8,7 @@ from twisted.internet import endpoints
 from . import transit_server
 from .server_state import create_usage_tracker
 from .increase_rlimits import increase_rlimits
+from .database import get_db
 
 LONGDESC = """\
 This plugin sets up a 'Transit Relay' server for magic-wormhole. This service

--- a/src/wormhole_transit_relay/test/common.py
+++ b/src/wormhole_transit_relay/test/common.py
@@ -1,5 +1,6 @@
 from twisted.test import proto_helpers
 from ..transit_server import Transit
+from ..server_state import create_usage_tracker
 
 class ServerBase:
     log_requests = False
@@ -10,8 +11,12 @@ class ServerBase:
         self._transit_server._debug_log = self.log_requests
 
     def _setup_relay(self, blur_usage=None, log_file=None, usage_db=None):
-        self._transit_server = Transit(blur_usage=blur_usage,
-                                       log_file=log_file, usage_db=usage_db)
+        usage = create_usage_tracker(
+            blur_usage=blur_usage,
+            log_file=log_file,
+            usage_db=usage_db,
+        )
+        self._transit_server = Transit(usage)
 
     def new_protocol(self):
         protocol = self._transit_server.buildProtocol(('127.0.0.1', 0))

--- a/src/wormhole_transit_relay/test/common.py
+++ b/src/wormhole_transit_relay/test/common.py
@@ -16,7 +16,7 @@ class ServerBase:
             log_file=log_file,
             usage_db=usage_db,
         )
-        self._transit_server = Transit(usage)
+        self._transit_server = Transit(usage, lambda: 123456789.0)
 
     def new_protocol(self):
         protocol = self._transit_server.buildProtocol(('127.0.0.1', 0))

--- a/src/wormhole_transit_relay/test/common.py
+++ b/src/wormhole_transit_relay/test/common.py
@@ -6,11 +6,7 @@ class ServerBase:
 
     def setUp(self):
         self._lp = None
-        if self.log_requests:
-            blur_usage = None
-        else:
-            blur_usage = 60.0
-        self._setup_relay(blur_usage=blur_usage)
+        self._setup_relay(blur_usage=60.0 if self.log_requests else None)
         self._transit_server._debug_log = self.log_requests
 
     def _setup_relay(self, blur_usage=None, log_file=None, usage_db=None):

--- a/src/wormhole_transit_relay/test/test_rlimits.py
+++ b/src/wormhole_transit_relay/test/test_rlimits.py
@@ -1,5 +1,5 @@
 from __future__ import print_function, unicode_literals
-import mock
+from unittest import mock
 from twisted.trial import unittest
 from ..increase_rlimits import increase_rlimits
 

--- a/src/wormhole_transit_relay/test/test_service.py
+++ b/src/wormhole_transit_relay/test/test_service.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals, print_function
 from twisted.trial import unittest
-import mock
+from unittest import mock
 from twisted.application.service import MultiService
 from .. import server_tap
 

--- a/src/wormhole_transit_relay/test/test_service.py
+++ b/src/wormhole_transit_relay/test/test_service.py
@@ -8,7 +8,7 @@ class Service(unittest.TestCase):
     def test_defaults(self):
         o = server_tap.Options()
         o.parseOptions([])
-        with mock.patch("wormhole_transit_relay.server_tap.transit_server.Transit") as t:
+        with mock.patch("wormhole_transit_relay.server_tap.create_usage_tracker") as t:
             s = server_tap.makeService(o)
         self.assertEqual(t.mock_calls,
                          [mock.call(blur_usage=None,
@@ -18,7 +18,7 @@ class Service(unittest.TestCase):
     def test_blur(self):
         o = server_tap.Options()
         o.parseOptions(["--blur-usage=60"])
-        with mock.patch("wormhole_transit_relay.server_tap.transit_server.Transit") as t:
+        with mock.patch("wormhole_transit_relay.server_tap.create_usage_tracker") as t:
             server_tap.makeService(o)
         self.assertEqual(t.mock_calls,
                          [mock.call(blur_usage=60,
@@ -28,7 +28,7 @@ class Service(unittest.TestCase):
         o = server_tap.Options()
         o.parseOptions(["--log-fd=99"])
         fd = object()
-        with mock.patch("wormhole_transit_relay.server_tap.transit_server.Transit") as t:
+        with mock.patch("wormhole_transit_relay.server_tap.create_usage_tracker") as t:
             with mock.patch("wormhole_transit_relay.server_tap.os.fdopen",
                             return_value=fd) as f:
                 server_tap.makeService(o)

--- a/src/wormhole_transit_relay/test/test_stats.py
+++ b/src/wormhole_transit_relay/test/test_stats.py
@@ -1,6 +1,6 @@
 from __future__ import print_function, unicode_literals
 import os, io, json, sqlite3
-import mock
+from unittest import mock
 from twisted.trial import unittest
 from ..transit_server import Transit
 from .. import database

--- a/src/wormhole_transit_relay/test/test_stats.py
+++ b/src/wormhole_transit_relay/test/test_stats.py
@@ -7,19 +7,16 @@ from ..server_state import create_usage_tracker
 from .. import database
 
 class DB(unittest.TestCase):
-    def open_db(self, dbfile):
-        db = sqlite3.connect(dbfile)
-        database._initialize_db_connection(db)
-        return db
 
     def test_db(self):
         T = 1519075308.0
         d = self.mktemp()
         os.mkdir(d)
         usage_db = os.path.join(d, "usage.sqlite")
+        db = database.get_db(usage_db)
         with mock.patch("time.time", return_value=T+0):
-            t = Transit(create_usage_tracker(blur_usage=None, log_file=None, usage_db=usage_db))
-        db = self.open_db(usage_db)
+            t = Transit(create_usage_tracker(blur_usage=None, log_file=None, usage_db=db))
+        self.assertEqual(len(t.usage._backends), 1)
         usage = list(t.usage._backends)[0]
 
         with mock.patch("time.time", return_value=T+1):

--- a/src/wormhole_transit_relay/test/test_stats.py
+++ b/src/wormhole_transit_relay/test/test_stats.py
@@ -9,19 +9,31 @@ from .. import database
 class DB(unittest.TestCase):
 
     def test_db(self):
+
         T = 1519075308.0
+
+        class Timer:
+            t = T
+            def __call__(self):
+                return self.t
+        get_time = Timer()
+
         d = self.mktemp()
         os.mkdir(d)
         usage_db = os.path.join(d, "usage.sqlite")
         db = database.get_db(usage_db)
-        with mock.patch("time.time", return_value=T+0):
-            t = Transit(create_usage_tracker(blur_usage=None, log_file=None, usage_db=db))
+        t = Transit(
+            create_usage_tracker(blur_usage=None, log_file=None, usage_db=db),
+            get_time,
+        )
         self.assertEqual(len(t.usage._backends), 1)
         usage = list(t.usage._backends)[0]
 
-        with mock.patch("time.time", return_value=T+1):
-            usage.record_usage(started=123, mood="happy", total_bytes=100,
-                          total_time=10, waiting_time=2)
+        get_time.t = T + 1
+        usage.record_usage(started=123, mood="happy", total_bytes=100,
+                           total_time=10, waiting_time=2)
+        t.update_stats()
+
         self.assertEqual(db.execute("SELECT * FROM `usage`").fetchall(),
                          [dict(result="happy", started=123,
                                total_bytes=100, total_time=10, waiting_time=2),
@@ -31,9 +43,10 @@ class DB(unittest.TestCase):
                               incomplete_bytes=0,
                               waiting=0, connected=0))
 
-        with mock.patch("time.time", return_value=T+2):
-            usage.record_usage(started=150, mood="errory", total_bytes=200,
-                          total_time=11, waiting_time=3)
+        get_time.t = T + 2
+        usage.record_usage(started=150, mood="errory", total_bytes=200,
+                           total_time=11, waiting_time=3)
+        t.update_stats()
         self.assertEqual(db.execute("SELECT * FROM `usage`").fetchall(),
                          [dict(result="happy", started=123,
                                total_bytes=100, total_time=10, waiting_time=2),
@@ -45,15 +58,18 @@ class DB(unittest.TestCase):
                               incomplete_bytes=0,
                               waiting=0, connected=0))
 
-        with mock.patch("time.time", return_value=T+3):
-            t.timerUpdateStats()
+        get_time.t = T + 3
+        t.update_stats()
         self.assertEqual(db.execute("SELECT * FROM `current`").fetchone(),
                          dict(rebooted=T+0, updated=T+3,
                               incomplete_bytes=0,
                               waiting=0, connected=0))
 
     def test_no_db(self):
-        t = Transit(create_usage_tracker(blur_usage=None, log_file=None, usage_db=None))
+        t = Transit(
+            create_usage_tracker(blur_usage=None, log_file=None, usage_db=None),
+            lambda: 0,
+        )
         self.assertEqual(0, len(t.usage._backends))
 
 
@@ -61,7 +77,10 @@ class LogToStdout(unittest.TestCase):
     def test_log(self):
         # emit lines of JSON to log_file, if set
         log_file = io.StringIO()
-        t = Transit(create_usage_tracker(blur_usage=None, log_file=log_file, usage_db=None))
+        t = Transit(
+            create_usage_tracker(blur_usage=None, log_file=log_file, usage_db=None),
+            lambda: 0,
+        )
         with mock.patch("time.time", return_value=133):
             t.usage.record(
                 started=123,
@@ -79,7 +98,10 @@ class LogToStdout(unittest.TestCase):
         # if blurring is enabled, timestamps should be rounded to the
         # requested amount, and sizes should be rounded up too
         log_file = io.StringIO()
-        t = Transit(create_usage_tracker(blur_usage=60, log_file=log_file, usage_db=None))
+        t = Transit(
+            create_usage_tracker(blur_usage=60, log_file=log_file, usage_db=None),
+            lambda: 0,
+        )
 
         with mock.patch("time.time", return_value=123 + 10):
             t.usage.record(
@@ -96,7 +118,10 @@ class LogToStdout(unittest.TestCase):
                           "mood": "happy"})
 
     def test_do_not_log(self):
-        t = Transit(create_usage_tracker(blur_usage=60, log_file=None, usage_db=None))
+        t = Transit(
+            create_usage_tracker(blur_usage=60, log_file=None, usage_db=None),
+            lambda: 0,
+        )
         t.usage.record(
             started=123,
             buddy_started=124,

--- a/src/wormhole_transit_relay/test/test_stats.py
+++ b/src/wormhole_transit_relay/test/test_stats.py
@@ -3,6 +3,7 @@ import os, io, json, sqlite3
 from unittest import mock
 from twisted.trial import unittest
 from ..transit_server import Transit
+from ..server_state import create_usage_tracker
 from .. import database
 
 class DB(unittest.TestCase):
@@ -17,7 +18,7 @@ class DB(unittest.TestCase):
         os.mkdir(d)
         usage_db = os.path.join(d, "usage.sqlite")
         with mock.patch("time.time", return_value=T+0):
-            t = Transit(blur_usage=None, log_file=None, usage_db=usage_db)
+            t = Transit(create_usage_tracker(blur_usage=None, log_file=None, usage_db=usage_db))
         db = self.open_db(usage_db)
         usage = list(t.usage._backends)[0]
 
@@ -55,7 +56,7 @@ class DB(unittest.TestCase):
                               waiting=0, connected=0))
 
     def test_no_db(self):
-        t = Transit(blur_usage=None, log_file=None, usage_db=None)
+        t = Transit(create_usage_tracker(blur_usage=None, log_file=None, usage_db=None))
         self.assertEqual(0, len(t.usage._backends))
 
 
@@ -63,7 +64,7 @@ class LogToStdout(unittest.TestCase):
     def test_log(self):
         # emit lines of JSON to log_file, if set
         log_file = io.StringIO()
-        t = Transit(blur_usage=None, log_file=log_file, usage_db=None)
+        t = Transit(create_usage_tracker(blur_usage=None, log_file=log_file, usage_db=None))
         with mock.patch("time.time", return_value=133):
             t.usage.record(
                 started=123,
@@ -81,7 +82,7 @@ class LogToStdout(unittest.TestCase):
         # if blurring is enabled, timestamps should be rounded to the
         # requested amount, and sizes should be rounded up too
         log_file = io.StringIO()
-        t = Transit(blur_usage=60, log_file=log_file, usage_db=None)
+        t = Transit(create_usage_tracker(blur_usage=60, log_file=log_file, usage_db=None))
 
         with mock.patch("time.time", return_value=123 + 10):
             t.usage.record(
@@ -98,7 +99,7 @@ class LogToStdout(unittest.TestCase):
                           "mood": "happy"})
 
     def test_do_not_log(self):
-        t = Transit(blur_usage=60, log_file=None, usage_db=None)
+        t = Transit(create_usage_tracker(blur_usage=60, log_file=None, usage_db=None))
         t.usage.record(
             started=123,
             buddy_started=124,

--- a/src/wormhole_transit_relay/test/test_stats.py
+++ b/src/wormhole_transit_relay/test/test_stats.py
@@ -87,7 +87,7 @@ class LogToStdout(unittest.TestCase):
                 buddy_started=125,
                 result="happy",
                 bytes_sent=11999,
-                buddy_bytes=8001,
+                buddy_bytes=0,
             )
         print(log_file.getvalue())
         self.assertEqual(json.loads(log_file.getvalue()),

--- a/src/wormhole_transit_relay/test/test_stats.py
+++ b/src/wormhole_transit_relay/test/test_stats.py
@@ -1,5 +1,5 @@
 from __future__ import print_function, unicode_literals
-import os, io, json, sqlite3
+import os, io, json
 from unittest import mock
 from twisted.trial import unittest
 from ..transit_server import Transit

--- a/src/wormhole_transit_relay/test/test_transit_server.py
+++ b/src/wormhole_transit_relay/test/test_transit_server.py
@@ -13,9 +13,11 @@ def handshake(token, side=None):
 
 class _Transit:
     def count(self):
-        return sum([len(potentials)
-                    for potentials
-                    in self._transit_server._pending_requests.values()])
+        return sum([
+            len(potentials)
+            for potentials
+            in self._transit_server.pending_requests._requests.values()
+        ])
 
     def test_blur_size(self):
         blur = transit_server.blur_size
@@ -48,7 +50,7 @@ class _Transit:
         self.assertEqual(self.count(), 0)
 
         # the token should be removed too
-        self.assertEqual(len(self._transit_server._pending_requests), 0)
+        self.assertEqual(len(self._transit_server.pending_requests._requests), 0)
 
     def test_both_unsided(self):
         p1 = self.new_protocol()
@@ -168,8 +170,8 @@ class _Transit:
         side2 = b"\x02"*8
         p3.dataReceived(handshake(token1, side=side2))
         self.assertEqual(self.count(), 0)
-        self.assertEqual(len(self._transit_server._pending_requests), 0)
-        self.assertEqual(len(self._transit_server._active_connections), 2)
+        self.assertEqual(len(self._transit_server.pending_requests._requests), 0)
+        self.assertEqual(len(self._transit_server.active_connections._connections), 2)
         # That will trigger a disconnect on exactly one of (p1 or p2).
         # The other connection should still be connected
         self.assertEqual(sum([int(t.transport.connected) for t in [p1, p2]]), 1)
@@ -398,7 +400,7 @@ class Usage(ServerBase, unittest.TestCase):
         self.assertEqual(self._usage[0]["mood"], "lonely")
 
         p2.dataReceived(handshake(token1, side=side2))
-        self.assertEqual(len(self._transit_server._pending_requests), 0)
+        self.assertEqual(len(self._transit_server.pending_requests._requests), 0)
         self.assertEqual(len(self._usage), 2, self._usage)
         self.assertEqual(self._usage[1]["mood"], "redundant")
 

--- a/src/wormhole_transit_relay/test/test_transit_server.py
+++ b/src/wormhole_transit_relay/test/test_transit_server.py
@@ -320,8 +320,7 @@ class Usage(ServerBase, unittest.TestCase):
 
         # that will log the "empty" usage event
         self.assertEqual(len(self._usage), 1, self._usage)
-        (started, result, total_bytes, total_time, waiting_time) = self._usage[0]
-        self.assertEqual(result, "empty", self._usage)
+        self.assertEqual(self._usage[0]["mood"], "empty", self._usage)
 
     def test_short(self):
         p1 = self.new_protocol()
@@ -340,8 +339,7 @@ class Usage(ServerBase, unittest.TestCase):
         # that will log the "errory" usage event, then drop the connection
         p1.transport.loseConnection()
         self.assertEqual(len(self._usage), 1, self._usage)
-        (started, result, total_bytes, total_time, waiting_time) = self._usage[0]
-        self.assertEqual(result, "errory", self._usage)
+        self.assertEqual(self._usage[0]["mood"], "errory", self._usage)
 
     def test_lonely(self):
         p1 = self.new_protocol()
@@ -353,9 +351,8 @@ class Usage(ServerBase, unittest.TestCase):
         p1.transport.loseConnection()
 
         self.assertEqual(len(self._usage), 1, self._usage)
-        (started, result, total_bytes, total_time, waiting_time) = self._usage[0]
-        self.assertEqual(result, "lonely", self._usage)
-        self.assertIdentical(waiting_time, None)
+        self.assertEqual(self._usage[0]["mood"], "lonely", self._usage)
+        self.assertIdentical(self._usage[0]["waiting_time"], None)
 
     def test_one_happy_one_jilted(self):
         p1 = self.new_protocol()
@@ -375,9 +372,8 @@ class Usage(ServerBase, unittest.TestCase):
         p1.transport.loseConnection()
 
         self.assertEqual(len(self._usage), 1, self._usage)
-        (started, result, total_bytes, total_time, waiting_time) = self._usage[0]
-        self.assertEqual(result, "happy", self._usage)
-        self.assertEqual(total_bytes, 20)
+        self.assertEqual(self._usage[0]["mood"], "happy", self._usage)
+        self.assertEqual(self._usage[0]["total_bytes"], 20)
         self.assertNotIdentical(waiting_time, None)
 
     def test_redundant(self):
@@ -399,18 +395,15 @@ class Usage(ServerBase, unittest.TestCase):
         p1c.transport.loseConnection()
 
         self.assertEqual(len(self._usage), 1, self._usage)
-        (started, result, total_bytes, total_time, waiting_time) = self._usage[0]
-        self.assertEqual(result, "lonely", self._usage)
+        self.assertEqual(self._usage[0]["mood"], "lonely")
 
         p2.dataReceived(handshake(token1, side=side2))
         self.assertEqual(len(self._transit_server._pending_requests), 0)
         self.assertEqual(len(self._usage), 2, self._usage)
-        (started, result, total_bytes, total_time, waiting_time) = self._usage[1]
-        self.assertEqual(result, "redundant", self._usage)
+        self.assertEqual(self._usage[1]["mood"], "redundant")
 
         # one of the these is unecessary, but probably harmless
         p1a.transport.loseConnection()
         p1b.transport.loseConnection()
         self.assertEqual(len(self._usage), 3, self._usage)
-        (started, result, total_bytes, total_time, waiting_time) = self._usage[2]
-        self.assertEqual(result, "happy", self._usage)
+        self.assertEqual(self._usage[2]["mood"], "happy")

--- a/src/wormhole_transit_relay/test/test_transit_server.py
+++ b/src/wormhole_transit_relay/test/test_transit_server.py
@@ -3,7 +3,10 @@ from binascii import hexlify
 from twisted.trial import unittest
 from .common import ServerBase
 from .. import transit_server
-from ..server_state import MemoryUsageRecorder
+from ..server_state import (
+    MemoryUsageRecorder,
+    blur_size,
+)
 
 def handshake(token, side=None):
     hs = b"please relay " + hexlify(token)
@@ -21,22 +24,21 @@ class _Transit:
         ])
 
     def test_blur_size(self):
-        blur = transit_server.blur_size
-        self.failUnlessEqual(blur(0), 0)
-        self.failUnlessEqual(blur(1), 10e3)
-        self.failUnlessEqual(blur(10e3), 10e3)
-        self.failUnlessEqual(blur(10e3+1), 20e3)
-        self.failUnlessEqual(blur(15e3), 20e3)
-        self.failUnlessEqual(blur(20e3), 20e3)
-        self.failUnlessEqual(blur(1e6), 1e6)
-        self.failUnlessEqual(blur(1e6+1), 2e6)
-        self.failUnlessEqual(blur(1.5e6), 2e6)
-        self.failUnlessEqual(blur(2e6), 2e6)
-        self.failUnlessEqual(blur(900e6), 900e6)
-        self.failUnlessEqual(blur(1000e6), 1000e6)
-        self.failUnlessEqual(blur(1050e6), 1100e6)
-        self.failUnlessEqual(blur(1100e6), 1100e6)
-        self.failUnlessEqual(blur(1150e6), 1200e6)
+        self.failUnlessEqual(blur_size(0), 0)
+        self.failUnlessEqual(blur_size(1), 10e3)
+        self.failUnlessEqual(blur_size(10e3), 10e3)
+        self.failUnlessEqual(blur_size(10e3+1), 20e3)
+        self.failUnlessEqual(blur_size(15e3), 20e3)
+        self.failUnlessEqual(blur_size(20e3), 20e3)
+        self.failUnlessEqual(blur_size(1e6), 1e6)
+        self.failUnlessEqual(blur_size(1e6+1), 2e6)
+        self.failUnlessEqual(blur_size(1.5e6), 2e6)
+        self.failUnlessEqual(blur_size(2e6), 2e6)
+        self.failUnlessEqual(blur_size(900e6), 900e6)
+        self.failUnlessEqual(blur_size(1000e6), 1000e6)
+        self.failUnlessEqual(blur_size(1050e6), 1100e6)
+        self.failUnlessEqual(blur_size(1100e6), 1100e6)
+        self.failUnlessEqual(blur_size(1150e6), 1200e6)
 
     def test_register(self):
         p1 = self.new_protocol()
@@ -304,17 +306,22 @@ class _Transit:
         # hang up before sending anything
         p1.transport.loseConnection()
 
+
 class TransitWithLogs(_Transit, ServerBase, unittest.TestCase):
     log_requests = True
+
 
 class TransitWithoutLogs(_Transit, ServerBase, unittest.TestCase):
     log_requests = False
 
+
 class Usage(ServerBase, unittest.TestCase):
+
     def setUp(self):
         super(Usage, self).setUp()
         self._usage = MemoryUsageRecorder()
         self._transit_server.usage.add_backend(self._usage)
+##        self._transit_server.usage._blur_usage = None
 
     def test_empty(self):
         p1 = self.new_protocol()

--- a/src/wormhole_transit_relay/test/test_transit_server.py
+++ b/src/wormhole_transit_relay/test/test_transit_server.py
@@ -2,7 +2,6 @@ from __future__ import print_function, unicode_literals
 from binascii import hexlify
 from twisted.trial import unittest
 from .common import ServerBase
-from .. import transit_server
 from ..server_state import (
     MemoryUsageRecorder,
     blur_size,

--- a/src/wormhole_transit_relay/test/test_transit_server.py
+++ b/src/wormhole_transit_relay/test/test_transit_server.py
@@ -376,7 +376,7 @@ class Usage(ServerBase, unittest.TestCase):
         self.assertEqual(len(self._usage), 1, self._usage)
         self.assertEqual(self._usage[0]["mood"], "happy", self._usage)
         self.assertEqual(self._usage[0]["total_bytes"], 20)
-        self.assertNotIdentical(waiting_time, None)
+        self.assertNotIdentical(self._usage[0]["waiting_time"], None)
 
     def test_redundant(self):
         p1a = self.new_protocol()

--- a/src/wormhole_transit_relay/test/test_transit_server.py
+++ b/src/wormhole_transit_relay/test/test_transit_server.py
@@ -320,7 +320,6 @@ class Usage(ServerBase, unittest.TestCase):
         super(Usage, self).setUp()
         self._usage = MemoryUsageRecorder()
         self._transit_server.usage.add_backend(self._usage)
-##        self._transit_server.usage._blur_usage = None
 
     def test_empty(self):
         p1 = self.new_protocol()

--- a/src/wormhole_transit_relay/test/test_transit_server.py
+++ b/src/wormhole_transit_relay/test/test_transit_server.py
@@ -311,10 +311,7 @@ class Usage(ServerBase, unittest.TestCase):
     def setUp(self):
         super(Usage, self).setUp()
         self._usage = []
-        def record(started, result, total_bytes, total_time, waiting_time):
-            self._usage.append((started, result, total_bytes,
-                                total_time, waiting_time))
-        self._transit_server.recordUsage = record
+        self._transit_server.usage.json_record = self._usage.append
 
     def test_empty(self):
         p1 = self.new_protocol()
@@ -334,8 +331,7 @@ class Usage(ServerBase, unittest.TestCase):
 
         # that will log the "empty" usage event
         self.assertEqual(len(self._usage), 1, self._usage)
-        (started, result, total_bytes, total_time, waiting_time) = self._usage[0]
-        self.assertEqual(result, "empty", self._usage)
+        self.assertEqual("empty", self._usage[0]["mood"])
 
     def test_errory(self):
         p1 = self.new_protocol()

--- a/src/wormhole_transit_relay/transit_server.py
+++ b/src/wormhole_transit_relay/transit_server.py
@@ -42,9 +42,6 @@ class TransitConnection(LineReceiver):
 
     MAX_LENGTH = 1024
 
-    def __init__(self):
-        self._total_sent = 0
-
     def send(self, data):
         """
         ITransitClient API
@@ -104,10 +101,10 @@ class TransitConnection(LineReceiver):
             side = new.group(2)
             return self._got_handshake(token, side)
 
-        # state-machine calls us via ITransitClient interface to do
-        # bad handshake etc.
+        # we should have been switched to "raw data" mode on the first
+        # line received (after which rawDataReceived() is called for
+        # all bytes) so getting here means a bad handshake.
         return self._state.bad_token()
-    #return self._state.got_bytes(line)
 
     def rawDataReceived(self, data):
         # We are an IPushProducer to our buddy's IConsumer, so they'll
@@ -117,7 +114,6 @@ class TransitConnection(LineReceiver):
         # point the sender will only transmit data as fast as the
         # receiver can handle it.
         self._state.got_bytes(data)
-        self._total_sent += len(data)
 
     def _got_handshake(self, token, side):
         self._state.please_relay_for_side(token, side)

--- a/src/wormhole_transit_relay/transit_server.py
+++ b/src/wormhole_transit_relay/transit_server.py
@@ -250,14 +250,6 @@ class Transit(protocol.ServerFactory):
         self.active_connections = ActiveConnections()
         self.pending_requests = PendingRequests(self.active_connections)
         self.usage = usage
-        if False:
-            # these logs-message should be made by the usage-tracker
-            # .. or in the "tap" setup?
-            if blur_usage:
-                log.msg("blurring access times to %d seconds" % self._blur_usage)
-                log.msg("not logging Transit connections to Twisted log")
-            else:
-                log.msg("not blurring access times")
         self._debug_log = False
 
         self._rebooted = time.time()

--- a/src/wormhole_transit_relay/transit_server.py
+++ b/src/wormhole_transit_relay/transit_server.py
@@ -57,16 +57,6 @@ class TransitConnection(LineReceiver):
             self._buddy._client.transport.loseConnection()
             self._buddy = None
 
-    def describeToken(self):
-        d = "-"
-        if self._got_token:
-            d = self._got_token[:16].decode("ascii")
-        if self._got_side:
-            d += "-" + self._got_side.decode("ascii")
-        else:
-            d += "-<unsided>"
-        return d
-
     def connectionMade(self):
         # ideally more like self._reactor.seconds() ... but Twisted
         # doesn't have a good way to get the reactor for a protocol
@@ -136,6 +126,7 @@ class TransitConnection(LineReceiver):
 # XXX this probably resulted in a log message we've not refactored yet
 #        self.factory.transitFinished(self, self._got_token, self._got_side,
 #                                     self.describeToken())
+# XXX describeToken -> self._state.get_token()
 
 
 

--- a/src/wormhole_transit_relay/transit_server.py
+++ b/src/wormhole_transit_relay/transit_server.py
@@ -270,8 +270,8 @@ class Transit(protocol.ServerFactory):
             self._db = get_db(usage_db)
         self._rebooted = time.time()
         # we don't track TransitConnections until they submit a token
-        self._pending_requests = defaultdict(set) # token -> set((side, TransitConnection))
-        self._active_connections = set() # TransitConnection
+##        self._pending_requests = defaultdict(set) # token -> set((side, TransitConnection))
+##        self._active_connections = set() # TransitConnection
 
     def transitFinished(self, tc, token, side, description):
         if token in self._pending_requests:

--- a/src/wormhole_transit_relay/transit_server.py
+++ b/src/wormhole_transit_relay/transit_server.py
@@ -53,7 +53,7 @@ class TransitConnection(LineReceiver):
         ITransitClient API
         """
         if self._buddy is not None:
-            # print("buddy_disconnected {}".format(self._buddy.get_token()))
+            log.msg("buddy_disconnected {}".format(self._buddy.get_token()))
             self._buddy._client.transport.loseConnection()
             self._buddy = None
 

--- a/src/wormhole_transit_relay/transit_server.py
+++ b/src/wormhole_transit_relay/transit_server.py
@@ -52,6 +52,7 @@ class TransitConnection(LineReceiver):
         """
         ITransitClient API
         """
+        print("buddy_disconnected {}".format(self._buddy.get_token()))
         self._buddy._client.transport.loseConnection()
         self._buddy = None
 

--- a/src/wormhole_transit_relay/transit_server.py
+++ b/src/wormhole_transit_relay/transit_server.py
@@ -52,9 +52,10 @@ class TransitConnection(LineReceiver):
         """
         ITransitClient API
         """
-        print("buddy_disconnected {}".format(self._buddy.get_token()))
-        self._buddy._client.transport.loseConnection()
-        self._buddy = None
+        if self._buddy is not None:
+            # print("buddy_disconnected {}".format(self._buddy.get_token()))
+            self._buddy._client.transport.loseConnection()
+            self._buddy = None
 
     def describeToken(self):
         d = "-"


### PR DESCRIPTION
This branch defines an explicit state-machine using `Automat` and makes some associated re-factors so that the current TCP protocol uses the new state-machine. In principal, this makes it easier to implement #17 (support for WebSockets) which would be a second user of the state-machine.

It is still a draft because:
- [ ] some logging has not yet been re-factored
- [ ] the "general statistics" are not updated in the database 