### PR TITLE
iosim.IOPump based tests

### DIFF
--- a/src/wormhole_transit_relay/test/common.py
+++ b/src/wormhole_transit_relay/test/common.py
@@ -83,9 +83,11 @@ class ServerBase:
 
             def connectionMade(self):
                 self.connected = True
+                return Protocol.connectionMade(self)
 
             def connectionLost(self, reason):
                 self.connected = False
+                return Protocol.connectionLost(self, reason)
 
             def send(self, data):
                 self.transport.write(data)

--- a/src/wormhole_transit_relay/test/common.py
+++ b/src/wormhole_transit_relay/test/common.py
@@ -1,28 +1,67 @@
 from twisted.test import proto_helpers
-from ..transit_server import Transit
+from twisted.internet.protocol import (
+    ServerFactory,
+    ClientFactory,
+    Protocol,
+)
+from twisted.test import iosim
+from ..transit_server import (
+    Transit,
+    TransitConnection,
+)
+
 
 class ServerBase:
     log_requests = False
 
     def setUp(self):
+        self._pumps = []
         self._lp = None
         if self.log_requests:
             blur_usage = None
         else:
             blur_usage = 60.0
         self._setup_relay(blur_usage=blur_usage)
-        self._transit_server._debug_log = self.log_requests
+
+    def flush(self):
+        for pump in self._pumps:
+            pump.flush()
 
     def _setup_relay(self, blur_usage=None, log_file=None, usage_db=None):
-        self._transit_server = Transit(blur_usage=blur_usage,
-                                       log_file=log_file, usage_db=usage_db)
+        self._transit_server = Transit(
+            blur_usage=blur_usage,
+            log_file=log_file,
+            usage_db=usage_db,
+        )
+        self._transit_server._debug_log = self.log_requests
 
     def new_protocol(self):
-        protocol = self._transit_server.buildProtocol(('127.0.0.1', 0))
-        transport = proto_helpers.StringTransportWithDisconnection()
-        protocol.makeConnection(transport)
-        transport.protocol = protocol
-        return protocol
+        server_protocol = self._transit_server.buildProtocol(('127.0.0.1', 0))
+
+        # XXX interface?
+        class TransitClientProtocolTcp(Protocol):
+            """
+            Speak the transit client protocol used by the tests over TCP
+            """
+            def send(self, data):
+                self.transport.write(data)
+
+            def disconnect(self):
+                self.transport.loseConnection()
+
+        client_factory = ClientFactory()
+        client_factory.protocol = TransitClientProtocolTcp
+        client_protocol = client_factory.buildProtocol(('127.0.0.1', 31337))
+
+        pump = iosim.connect(
+            server_protocol,
+            iosim.makeFakeServer(server_protocol),
+            client_protocol,
+            iosim.makeFakeClient(client_protocol),
+        )
+        pump.flush()
+        self._pumps.append(pump)
+        return client_protocol
 
     def tearDown(self):
         if self._lp:

--- a/src/wormhole_transit_relay/test/common.py
+++ b/src/wormhole_transit_relay/test/common.py
@@ -1,13 +1,10 @@
-from twisted.test import proto_helpers
 from twisted.internet.protocol import (
-    ServerFactory,
     ClientFactory,
     Protocol,
 )
 from twisted.test import iosim
 from ..transit_server import (
     Transit,
-    TransitConnection,
 )
 
 

--- a/src/wormhole_transit_relay/test/common.py
+++ b/src/wormhole_transit_relay/test/common.py
@@ -81,6 +81,8 @@ class ServerBase:
             _received = b""
             connected = False
 
+            # override Protocol callbacks
+
             def connectionMade(self):
                 self.connected = True
                 return Protocol.connectionMade(self)
@@ -89,14 +91,16 @@ class ServerBase:
                 self.connected = False
                 return Protocol.connectionLost(self, reason)
 
+            def dataReceived(self, data):
+                self._received = self._received + data
+
+            # ITransitClient API
+
             def send(self, data):
                 self.transport.write(data)
 
             def disconnect(self):
                 self.transport.loseConnection()
-
-            def dataReceived(self, data):
-                self._received = self._received + data
 
             def reset_received_data(self):
                 self._received = b""

--- a/src/wormhole_transit_relay/test/common.py
+++ b/src/wormhole_transit_relay/test/common.py
@@ -13,7 +13,7 @@ from ..transit_server import (
 )
 
 
-class ITransitClient(Interface):
+class IRelayTestClient(Interface):
     """
     The client interface used by tests.
     """
@@ -69,11 +69,11 @@ class ServerBase:
     def new_protocol(self):
         """
         Create a new client protocol connected to the server.
-        :returns: a ITransitClient implementation
+        :returns: a IRelayTestClient implementation
         """
         server_protocol = self._transit_server.buildProtocol(('127.0.0.1', 0))
 
-        @implementer(ITransitClient)
+        @implementer(IRelayTestClient)
         class TransitClientProtocolTcp(Protocol):
             """
             Speak the transit client protocol used by the tests over TCP
@@ -94,7 +94,7 @@ class ServerBase:
             def dataReceived(self, data):
                 self._received = self._received + data
 
-            # ITransitClient API
+            # IRelayTestClient
 
             def send(self, data):
                 self.transport.write(data)

--- a/src/wormhole_transit_relay/test/common.py
+++ b/src/wormhole_transit_relay/test/common.py
@@ -55,8 +55,11 @@ class ServerBase:
         self._setup_relay(blur_usage=blur_usage)
 
     def flush(self):
+        did_work = False
         for pump in self._pumps:
-            pump.flush()
+            did_work = pump.flush() or did_work
+        if did_work:
+            self.flush()
 
     def _setup_relay(self, blur_usage=None, log_file=None, usage_db=None):
         self._transit_server = Transit(

--- a/src/wormhole_transit_relay/test/common.py
+++ b/src/wormhole_transit_relay/test/common.py
@@ -43,11 +43,24 @@ class ServerBase:
             """
             Speak the transit client protocol used by the tests over TCP
             """
+            received = b""
+            connected = False
+
+            def connectionMade(self):
+                self.connected = True
+
+            def connectionLost(self, reason):
+                self.connected = False
+
             def send(self, data):
                 self.transport.write(data)
 
             def disconnect(self):
                 self.transport.loseConnection()
+
+            def dataReceived(self, data):
+                self.received = self.received + data
+
 
         client_factory = ClientFactory()
         client_factory.protocol = TransitClientProtocolTcp

--- a/src/wormhole_transit_relay/test/test_rlimits.py
+++ b/src/wormhole_transit_relay/test/test_rlimits.py
@@ -1,5 +1,5 @@
 from __future__ import print_function, unicode_literals
-import mock
+from unittest import mock
 from twisted.trial import unittest
 from ..increase_rlimits import increase_rlimits
 

--- a/src/wormhole_transit_relay/test/test_rlimits.py
+++ b/src/wormhole_transit_relay/test/test_rlimits.py
@@ -1,5 +1,8 @@
 from __future__ import print_function, unicode_literals
-from unittest import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 from twisted.trial import unittest
 from ..increase_rlimits import increase_rlimits
 

--- a/src/wormhole_transit_relay/test/test_service.py
+++ b/src/wormhole_transit_relay/test/test_service.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals, print_function
 from twisted.trial import unittest
-import mock
+from unittest import mock
 from twisted.application.service import MultiService
 from .. import server_tap
 

--- a/src/wormhole_transit_relay/test/test_service.py
+++ b/src/wormhole_transit_relay/test/test_service.py
@@ -1,6 +1,9 @@
 from __future__ import unicode_literals, print_function
 from twisted.trial import unittest
-from unittest import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 from twisted.application.service import MultiService
 from .. import server_tap
 

--- a/src/wormhole_transit_relay/test/test_stats.py
+++ b/src/wormhole_transit_relay/test/test_stats.py
@@ -1,6 +1,6 @@
 from __future__ import print_function, unicode_literals
 import os, io, json, sqlite3
-import mock
+from unittest import mock
 from twisted.trial import unittest
 from ..transit_server import Transit
 from .. import database

--- a/src/wormhole_transit_relay/test/test_stats.py
+++ b/src/wormhole_transit_relay/test/test_stats.py
@@ -1,6 +1,9 @@
 from __future__ import print_function, unicode_literals
 import os, io, json, sqlite3
-from unittest import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 from twisted.trial import unittest
 from ..transit_server import Transit
 from .. import database

--- a/src/wormhole_transit_relay/test/test_transit_server.py
+++ b/src/wormhole_transit_relay/test/test_transit_server.py
@@ -338,6 +338,8 @@ class TransitWithoutLogs(_Transit, ServerBase, unittest.TestCase):
     log_requests = False
 
 class Usage(ServerBase, unittest.TestCase):
+    log_requests = True
+
     def setUp(self):
         super(Usage, self).setUp()
         self._usage = []

--- a/src/wormhole_transit_relay/test/test_transit_server.py
+++ b/src/wormhole_transit_relay/test/test_transit_server.py
@@ -61,7 +61,6 @@ class _Transit:
         self.flush()
         p2.send(handshake(token1, side=None))
         self.flush()
-        self.flush()
 
         # a correct handshake yields an ack, after which we can send
         exp = b"ok\n"
@@ -89,7 +88,6 @@ class _Transit:
         self.flush()
         p2.send(handshake(token1, side=None))
         self.flush()
-        self.flush()
 
         # a correct handshake yields an ack, after which we can send
         exp = b"ok\n"
@@ -116,7 +114,6 @@ class _Transit:
         side1 = b"\x01"*8
         p1.send(handshake(token1, side=None))
         p2.send(handshake(token1, side=side1))
-        self.flush()
         self.flush()
 
         # a correct handshake yields an ack, after which we can send
@@ -146,7 +143,6 @@ class _Transit:
         p1.send(handshake(token1, side=side1))
         self.flush()
         p2.send(handshake(token1, side=side2))
-        self.flush()
         self.flush()
 
         # a correct handshake yields an ack, after which we can send
@@ -186,7 +182,6 @@ class _Transit:
         # closed
         side2 = b"\x02"*8
         p3.send(handshake(token1, side=side2))
-        self.flush()
         self.flush()
         self.assertEqual(self.count(), 0)
         self.assertEqual(len(self._transit_server._pending_requests), 0)
@@ -452,7 +447,6 @@ class Usage(ServerBase, unittest.TestCase):
         self.assertEqual(result, "lonely", self._usage)
 
         p2.send(handshake(token1, side=side2))
-        self.flush()
         self.flush()
         self.assertEqual(len(self._transit_server._pending_requests), 0)
         self.assertEqual(len(self._usage), 2, self._usage)

--- a/src/wormhole_transit_relay/test/test_transit_server.py
+++ b/src/wormhole_transit_relay/test/test_transit_server.py
@@ -77,6 +77,7 @@ class _Transit:
 
         p1.disconnect()
         p2.disconnect()
+        self.flush()
 
     def test_sided_unsided(self):
         p1 = self.new_protocol()
@@ -105,6 +106,7 @@ class _Transit:
 
         p1.disconnect()
         p2.disconnect()
+        self.flush()
 
     def test_unsided_sided(self):
         p1 = self.new_protocol()

--- a/src/wormhole_transit_relay/test/test_transit_server.py
+++ b/src/wormhole_transit_relay/test/test_transit_server.py
@@ -65,16 +65,16 @@ class _Transit:
 
         # a correct handshake yields an ack, after which we can send
         exp = b"ok\n"
-        self.assertEqual(p1.received, exp)
-        self.assertEqual(p2.received, exp)
+        self.assertEqual(p1.get_received_data(), exp)
+        self.assertEqual(p2.get_received_data(), exp)
 
-        p1.received = b""
-        p2.received = b""
+        p1.reset_received_data()
+        p2.reset_received_data()
 
         s1 = b"data1"
         p1.send(s1)
         self.flush()
-        self.assertEqual(p2.received, s1)
+        self.assertEqual(p2.get_received_data(), s1)
 
         p1.disconnect()
         p2.disconnect()
@@ -93,17 +93,17 @@ class _Transit:
 
         # a correct handshake yields an ack, after which we can send
         exp = b"ok\n"
-        self.assertEqual(p1.received, exp)
-        self.assertEqual(p2.received, exp)
+        self.assertEqual(p1.get_received_data(), exp)
+        self.assertEqual(p2.get_received_data(), exp)
 
-        p1.received = b""
-        p2.received = b""
+        p1.reset_received_data()
+        p2.reset_received_data()
 
         # all data they sent after the handshake should be given to us
         s1 = b"data1"
         p1.send(s1)
         self.flush()
-        self.assertEqual(p2.received, s1)
+        self.assertEqual(p2.get_received_data(), s1)
 
         p1.disconnect()
         p2.disconnect()
@@ -121,17 +121,17 @@ class _Transit:
 
         # a correct handshake yields an ack, after which we can send
         exp = b"ok\n"
-        self.assertEqual(p1.received, exp)
-        self.assertEqual(p2.received, exp)
+        self.assertEqual(p1.get_received_data(), exp)
+        self.assertEqual(p2.get_received_data(), exp)
 
-        p1.received = b""
-        p2.received = b""
+        p1.reset_received_data()
+        p2.reset_received_data()
 
         # all data they sent after the handshake should be given to us
         s1 = b"data1"
         p1.send(s1)
         self.flush()
-        self.assertEqual(p2.received, s1)
+        self.assertEqual(p2.get_received_data(), s1)
 
         p1.disconnect()
         p2.disconnect()
@@ -151,17 +151,17 @@ class _Transit:
 
         # a correct handshake yields an ack, after which we can send
         exp = b"ok\n"
-        self.assertEqual(p1.received, exp)
-        self.assertEqual(p2.received, exp)
+        self.assertEqual(p1.get_received_data(), exp)
+        self.assertEqual(p2.get_received_data(), exp)
 
-        p1.received = b""
-        p2.received = b""
+        p1.reset_received_data()
+        p2.reset_received_data()
 
         # all data they sent after the handshake should be given to us
         s1 = b"data1"
         p1.send(s1)
         self.flush()
-        self.assertEqual(p2.received, s1)
+        self.assertEqual(p2.get_received_data(), s1)
 
         p1.disconnect()
         p2.disconnect()
@@ -207,7 +207,7 @@ class _Transit:
         self.flush()
 
         exp = b"bad handshake\n"
-        self.assertEqual(p1.received, exp)
+        self.assertEqual(p1.get_received_data(), exp)
         p1.disconnect()
 
     def test_bad_handshake_old_slow(self):
@@ -227,7 +227,7 @@ class _Transit:
         self.flush()
 
         exp = b"bad handshake\n"
-        self.assertEqual(p1.received, exp)
+        self.assertEqual(p1.get_received_data(), exp)
 
         p1.disconnect()
 
@@ -243,7 +243,7 @@ class _Transit:
         self.flush()
 
         exp = b"bad handshake\n"
-        self.assertEqual(p1.received, exp)
+        self.assertEqual(p1.get_received_data(), exp)
 
         p1.disconnect()
 
@@ -261,7 +261,7 @@ class _Transit:
         self.flush()
 
         exp = b"bad handshake\n"
-        self.assertEqual(p1.received, exp)
+        self.assertEqual(p1.get_received_data(), exp)
 
         p1.disconnect()
 
@@ -274,7 +274,7 @@ class _Transit:
         self.flush()
 
         exp = b"impatient\n"
-        self.assertEqual(p1.received, exp)
+        self.assertEqual(p1.get_received_data(), exp)
 
         p1.disconnect()
 
@@ -289,7 +289,7 @@ class _Transit:
         self.flush()
 
         exp = b"impatient\n"
-        self.assertEqual(p1.received, exp)
+        self.assertEqual(p1.get_received_data(), exp)
 
         p1.disconnect()
 
@@ -315,7 +315,7 @@ class _Transit:
         self.flush()
 
         exp = b"impatient\n"
-        self.assertEqual(p1.received, exp)
+        self.assertEqual(p1.get_received_data(), exp)
 
         p1.disconnect()
 

--- a/src/wormhole_transit_relay/test/test_transit_server.py
+++ b/src/wormhole_transit_relay/test/test_transit_server.py
@@ -41,10 +41,12 @@ class _Transit:
         token1 = b"\x00"*32
         side1 = b"\x01"*8
 
-        p1.dataReceived(handshake(token1, side1))
+        p1.send(handshake(token1, side1))
+        self.flush()
         self.assertEqual(self.count(), 1)
 
-        p1.transport.loseConnection()
+        p1.disconnect()
+        self.flush()
         self.assertEqual(self.count(), 0)
 
         # the token should be removed too

--- a/src/wormhole_transit_relay/transit_server.py
+++ b/src/wormhole_transit_relay/transit_server.py
@@ -84,16 +84,16 @@ class TransitConnection(LineReceiver):
         # point the sender will only transmit data as fast as the
         # receiver can handle it.
         if self._sent_ok:
-            if not self._buddy:
-                # Our buddy disconnected (we're "jilted"), so we hung up too,
-                # but our incoming data hasn't stopped yet (it will in a
-                # moment, after our disconnect makes a roundtrip through the
-                # kernel). This probably means the file receiver hung up, and
-                # this connection is the file sender. In may-2020 this
-                # happened 11 times in 40 days.
-                return
-            self._total_sent += len(data)
-            self._buddy.transport.write(data)
+            # if self._buddy is None then our buddy disconnected
+            # (we're "jilted"), so we hung up too, but our incoming
+            # data hasn't stopped yet (it will in a moment, after our
+            # disconnect makes a roundtrip through the kernel). This
+            # probably means the file receiver hung up, and this
+            # connection is the file sender. In may-2020 this happened
+            # 11 times in 40 days.
+            if self._buddy:
+                self._total_sent += len(data)
+                self._buddy.transport.write(data)
             return
 
         # handshake is complete but not yet sent_ok


### PR DESCRIPTION
This is essentially back-story for WebSocket support .. this switches the tests to use `iosim` so that we use a real client -> server protocol and transport. This also uses a consistent client protocol. For TCP this isn't substantially different from just directly tweaking Twisted APIs. For WebSocket this is necessary (because the client has to do a WebSocket negotiation properly before it can send messages).

Also changes "mock" location to match python3