### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v2

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@ User-visible changes in "magic-wormhole-transit-relay":
 
 ## unreleased
 
+* Drop Pythons from 3.9 and earlier (3.9 is EOL in a few months)
 * (put release notes here when adding PRs)
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = {py37,py38,py39,py310,py311,py312,pypy}
+envlist = {py310,py311,py312,pypy}
 skip_missing_interpreters = True
 minversion = 2.4.0
 


### PR DESCRIPTION
Python 3.9 and earlier are EOL (well, 3.9 itself not for a few months, but ...)