### PR TITLE
remove 'u' prefix to strings

### DIFF
--- a/client.py
+++ b/client.py
@@ -27,7 +27,7 @@ class RelayEchoClient(Protocol):
     def connectionMade(self):
         print(">CONNECT")
         self.data = b""
-        self.transport.write(u"please relay {}\n".format(self.factory.token).encode("ascii"))
+        self.transport.write("please relay {}\n".format(self.factory.token).encode("ascii"))
 
     def dataReceived(self, data):
         print(">RECV {} bytes".format(len(data)))

--- a/src/wormhole_transit_relay/test/test_transit_server.py
+++ b/src/wormhole_transit_relay/test/test_transit_server.py
@@ -669,7 +669,7 @@ class UsageWebSockets(Usage):
         ws_factory.protocol = WebSocketTransitConnection
         ws_protocol = ws_factory.buildProtocol(('127.0.0.1', 0))
         with self.assertRaises(ValueError):
-            ws_protocol.onMessage(u"foo", isBinary=False)
+            ws_protocol.onMessage("foo", isBinary=False)
 
 
 class State(unittest.TestCase):

--- a/ws_client.py
+++ b/ws_client.py
@@ -27,7 +27,7 @@ class RelayEchoClient(WebSocketClientProtocol):
     def onOpen(self):
         self._received = b""
         self.sendMessage(
-            u"please relay {} for side {}".format(
+            "please relay {} for side {}".format(
                 self.factory.token,
                 self.factory.side,
             ).encode("ascii"),


### PR DESCRIPTION

It's unneeded and more consistent with the other strings.

The patch is equivalent to https://github.com/magic-wormhole/magic-wormhole/pull/636