### PR TITLE
fix: remove syntax warnings

### DIFF
--- a/src/wormhole_transit_relay/server_tap.py
+++ b/src/wormhole_transit_relay/server_tap.py
@@ -25,7 +25,7 @@ class Options(usage.Options):
     longdesc = LONGDESC
 
     optParameters = [
-        ("port", "p", "tcp:4001:interface=\:\:", "endpoint to listen on"),
+        ("port", "p", r"tcp:4001:interface=\:\:", "endpoint to listen on"),
         ("websocket", "w", None, "endpoint to listen for WebSocket connections"),
         ("websocket-url", "u", None, "WebSocket URL (derived from endpoint if not provided)"),
         ("blur-usage", None, None, "blur timestamps and data sizes in logs"),

--- a/src/wormhole_transit_relay/test/test_config.py
+++ b/src/wormhole_transit_relay/test/test_config.py
@@ -1,7 +1,7 @@
 from twisted.trial import unittest
 from .. import server_tap
 
-PORT = "tcp:4001:interface=\:\:"
+PORT = r"tcp:4001:interface=\:\:"
 
 class Config(unittest.TestCase):
     def test_defaults(self):


### PR DESCRIPTION
Use raw strings to remove invalid escape sequence warnings. For example (at least) in python 3.13:

```
src/wormhole_mailbox_server/server_tap.py:22: SyntaxWarning: invalid escape sequence ':'
  ("port", "p", "tcp:4000:interface=::", "endpoint to listen on"),