### PR TITLE
style: update syntax to recent Python versions

### DIFF
--- a/client.py
+++ b/client.py
@@ -27,10 +27,10 @@ class RelayEchoClient(Protocol):
     def connectionMade(self):
         print(">CONNECT")
         self.data = b""
-        self.transport.write("please relay {}\n".format(self.factory.token).encode("ascii"))
+        self.transport.write(f"please relay {self.factory.token}\n".encode("ascii"))
 
     def dataReceived(self, data):
-        print(">RECV {} bytes".format(len(data)))
+        print(f">RECV {len(data)} bytes")
         print(data.decode("ascii"))
         self.data += data
         if data == "ok\n":
@@ -40,7 +40,7 @@ class RelayEchoClient(Protocol):
         if isinstance(reason.value, ConnectionDone):
             self.factory.done.callback(None)
         else:
-            print(">DISCONNCT: {}".format(reason))
+            print(f">DISCONNCT: {reason}")
             self.factory.done.callback(reason)
 
 

--- a/src/wormhole_transit_relay/__init__.py
+++ b/src/wormhole_transit_relay/__init__.py
@@ -1,3 +1,2 @@
-
 from . import _version
 __version__ = _version.get_versions()['version']

--- a/src/wormhole_transit_relay/_version.py
+++ b/src/wormhole_transit_relay/_version.py
@@ -1,4 +1,3 @@
-
 # This file helps to compute a version number in source trees obtained from
 # git-archive tarball (such as those provided by githubs download-from-tag
 # feature). Distribution tarballs (built by setup.py sdist) and build
@@ -16,11 +15,11 @@ import os
 import re
 import subprocess
 import sys
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Optional
 import functools
 
 
-def get_keywords() -> Dict[str, str]:
+def get_keywords() -> dict[str, str]:
     """Get the keywords needed to look up the version information."""
     # these strings will be replaced by git during git-archive.
     # setup.py/versioneer.py will grep for the variable names, so they must
@@ -62,8 +61,8 @@ class NotThisMethod(Exception):
     """Exception raised if a method is not valid for the current scenario."""
 
 
-LONG_VERSION_PY: Dict[str, str] = {}
-HANDLERS: Dict[str, Dict[str, Callable]] = {}
+LONG_VERSION_PY: dict[str, str] = {}
+HANDLERS: dict[str, dict[str, Callable]] = {}
 
 
 def register_vcs_handler(vcs: str, method: str) -> Callable:  # decorator
@@ -78,18 +77,18 @@ def register_vcs_handler(vcs: str, method: str) -> Callable:  # decorator
 
 
 def run_command(
-    commands: List[str],
-    args: List[str],
+    commands: list[str],
+    args: list[str],
     cwd: Optional[str] = None,
     verbose: bool = False,
     hide_stderr: bool = False,
-    env: Optional[Dict[str, str]] = None,
-) -> Tuple[Optional[str], Optional[int]]:
+    env: Optional[dict[str, str]] = None,
+) -> tuple[Optional[str], Optional[int]]:
     """Call the given command(s)."""
     assert isinstance(commands, list)
     process = None
 
-    popen_kwargs: Dict[str, Any] = {}
+    popen_kwargs: dict[str, Any] = {}
     if sys.platform == "win32":
         # This hides the console window if pythonw.exe is used
         startupinfo = subprocess.STARTUPINFO()
@@ -129,7 +128,7 @@ def versions_from_parentdir(
     parentdir_prefix: str,
     root: str,
     verbose: bool,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Try to determine the version from the parent directory name.
 
     Source tarballs conventionally unpack into a directory that includes both
@@ -154,15 +153,15 @@ def versions_from_parentdir(
 
 
 @register_vcs_handler("git", "get_keywords")
-def git_get_keywords(versionfile_abs: str) -> Dict[str, str]:
+def git_get_keywords(versionfile_abs: str) -> dict[str, str]:
     """Extract version information from the given file."""
     # the code embedded in _version.py can just fetch the value of these
     # keywords. When used from setup.py, we don't want to import _version.py,
     # so we do it with a regexp instead. This function is not used from
     # _version.py.
-    keywords: Dict[str, str] = {}
+    keywords: dict[str, str] = {}
     try:
-        with open(versionfile_abs, "r") as fobj:
+        with open(versionfile_abs) as fobj:
             for line in fobj:
                 if line.strip().startswith("git_refnames ="):
                     mo = re.search(r'=\s*"(.*)"', line)
@@ -183,10 +182,10 @@ def git_get_keywords(versionfile_abs: str) -> Dict[str, str]:
 
 @register_vcs_handler("git", "keywords")
 def git_versions_from_keywords(
-    keywords: Dict[str, str],
+    keywords: dict[str, str],
     tag_prefix: str,
     verbose: bool,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Get version information from git keywords."""
     if "refnames" not in keywords:
         raise NotThisMethod("Short version file found")
@@ -255,7 +254,7 @@ def git_pieces_from_vcs(
     root: str,
     verbose: bool,
     runner: Callable = run_command
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Get version from 'git describe' in the root of the source tree.
 
     This only gets called if the git-archive 'subst' keywords were *not*
@@ -295,7 +294,7 @@ def git_pieces_from_vcs(
         raise NotThisMethod("'git rev-parse' failed")
     full_out = full_out.strip()
 
-    pieces: Dict[str, Any] = {}
+    pieces: dict[str, Any] = {}
     pieces["long"] = full_out
     pieces["short"] = full_out[:7]  # maybe improved later
     pieces["error"] = None
@@ -386,14 +385,14 @@ def git_pieces_from_vcs(
     return pieces
 
 
-def plus_or_dot(pieces: Dict[str, Any]) -> str:
+def plus_or_dot(pieces: dict[str, Any]) -> str:
     """Return a + if we don't already have one, else return a ."""
     if "+" in pieces.get("closest-tag", ""):
         return "."
     return "+"
 
 
-def render_pep440(pieces: Dict[str, Any]) -> str:
+def render_pep440(pieces: dict[str, Any]) -> str:
     """Build up version string, with post-release "local version identifier".
 
     Our goal: TAG[+DISTANCE.gHEX[.dirty]] . Note that if you
@@ -418,7 +417,7 @@ def render_pep440(pieces: Dict[str, Any]) -> str:
     return rendered
 
 
-def render_pep440_branch(pieces: Dict[str, Any]) -> str:
+def render_pep440_branch(pieces: dict[str, Any]) -> str:
     """TAG[[.dev0]+DISTANCE.gHEX[.dirty]] .
 
     The ".dev0" means not master branch. Note that .dev0 sorts backwards
@@ -448,7 +447,7 @@ def render_pep440_branch(pieces: Dict[str, Any]) -> str:
     return rendered
 
 
-def pep440_split_post(ver: str) -> Tuple[str, Optional[int]]:
+def pep440_split_post(ver: str) -> tuple[str, Optional[int]]:
     """Split pep440 version string at the post-release segment.
 
     Returns the release segments before the post-release and the
@@ -458,7 +457,7 @@ def pep440_split_post(ver: str) -> Tuple[str, Optional[int]]:
     return vc[0], int(vc[1] or 0) if len(vc) == 2 else None
 
 
-def render_pep440_pre(pieces: Dict[str, Any]) -> str:
+def render_pep440_pre(pieces: dict[str, Any]) -> str:
     """TAG[.postN.devDISTANCE] -- No -dirty.
 
     Exceptions:
@@ -482,7 +481,7 @@ def render_pep440_pre(pieces: Dict[str, Any]) -> str:
     return rendered
 
 
-def render_pep440_post(pieces: Dict[str, Any]) -> str:
+def render_pep440_post(pieces: dict[str, Any]) -> str:
     """TAG[.postDISTANCE[.dev0]+gHEX] .
 
     The ".dev0" means dirty. Note that .dev0 sorts backwards
@@ -509,7 +508,7 @@ def render_pep440_post(pieces: Dict[str, Any]) -> str:
     return rendered
 
 
-def render_pep440_post_branch(pieces: Dict[str, Any]) -> str:
+def render_pep440_post_branch(pieces: dict[str, Any]) -> str:
     """TAG[.postDISTANCE[.dev0]+gHEX[.dirty]] .
 
     The ".dev0" means not master branch.
@@ -538,7 +537,7 @@ def render_pep440_post_branch(pieces: Dict[str, Any]) -> str:
     return rendered
 
 
-def render_pep440_old(pieces: Dict[str, Any]) -> str:
+def render_pep440_old(pieces: dict[str, Any]) -> str:
     """TAG[.postDISTANCE[.dev0]] .
 
     The ".dev0" means dirty.
@@ -560,7 +559,7 @@ def render_pep440_old(pieces: Dict[str, Any]) -> str:
     return rendered
 
 
-def render_git_describe(pieces: Dict[str, Any]) -> str:
+def render_git_describe(pieces: dict[str, Any]) -> str:
     """TAG[-DISTANCE-gHEX][-dirty].
 
     Like 'git describe --tags --dirty --always'.
@@ -580,7 +579,7 @@ def render_git_describe(pieces: Dict[str, Any]) -> str:
     return rendered
 
 
-def render_git_describe_long(pieces: Dict[str, Any]) -> str:
+def render_git_describe_long(pieces: dict[str, Any]) -> str:
     """TAG-DISTANCE-gHEX[-dirty].
 
     Like 'git describe --tags --dirty --always -long'.
@@ -600,7 +599,7 @@ def render_git_describe_long(pieces: Dict[str, Any]) -> str:
     return rendered
 
 
-def render(pieces: Dict[str, Any], style: str) -> Dict[str, Any]:
+def render(pieces: dict[str, Any], style: str) -> dict[str, Any]:
     """Render the given version pieces into the requested style."""
     if pieces["error"]:
         return {"version": "unknown",
@@ -636,7 +635,7 @@ def render(pieces: Dict[str, Any], style: str) -> Dict[str, Any]:
             "date": pieces.get("date")}
 
 
-def get_versions() -> Dict[str, Any]:
+def get_versions() -> dict[str, Any]:
     """Get version information or return default if unable to do so."""
     # I am in _version.py, which lives at ROOT/VERSIONFILE_SOURCE. If we have
     # __file__, we can work backwards from there to the root. Some

--- a/src/wormhole_transit_relay/database.py
+++ b/src/wormhole_transit_relay/database.py
@@ -51,7 +51,7 @@ def _open_db_connection(dbfile):
     try:
         db = sqlite3.connect(dbfile)
         _initialize_db_connection(db)
-    except (EnvironmentError, sqlite3.OperationalError, sqlite3.DatabaseError) as e:
+    except (OSError, sqlite3.OperationalError, sqlite3.DatabaseError) as e:
         # this indicates that the file is not a compatible database format.
         # Perhaps it was created with an old version, or it might be junk.
         raise DBError(f"Unable to create/open db file {dbfile}: {e}")

--- a/src/wormhole_transit_relay/server_state.py
+++ b/src/wormhole_transit_relay/server_state.py
@@ -38,7 +38,7 @@ class ITransitClient(Interface):
         """
 
 
-class ActiveConnections(object):
+class ActiveConnections:
     """
     Tracks active connections.
 
@@ -68,7 +68,7 @@ class ActiveConnections(object):
         self._connections.discard(side)
 
 
-class PendingRequests(object):
+class PendingRequests:
     """
     Tracks outstanding (non-"active") requests.
 
@@ -145,7 +145,7 @@ class PendingRequests(object):
         # TODO: timer
 
 
-class TransitServerState(object):
+class TransitServerState:
     """
     Encapsulates the state-machine of the server side of a transit
     relay connection.

--- a/src/wormhole_transit_relay/test/test_transit_server.py
+++ b/src/wormhole_transit_relay/test/test_transit_server.py
@@ -42,21 +42,21 @@ class _Transit:
         ])
 
     def test_blur_size(self):
-        self.failUnlessEqual(blur_size(0), 0)
-        self.failUnlessEqual(blur_size(1), 10e3)
-        self.failUnlessEqual(blur_size(10e3), 10e3)
-        self.failUnlessEqual(blur_size(10e3+1), 20e3)
-        self.failUnlessEqual(blur_size(15e3), 20e3)
-        self.failUnlessEqual(blur_size(20e3), 20e3)
-        self.failUnlessEqual(blur_size(1e6), 1e6)
-        self.failUnlessEqual(blur_size(1e6+1), 2e6)
-        self.failUnlessEqual(blur_size(1.5e6), 2e6)
-        self.failUnlessEqual(blur_size(2e6), 2e6)
-        self.failUnlessEqual(blur_size(900e6), 900e6)
-        self.failUnlessEqual(blur_size(1000e6), 1000e6)
-        self.failUnlessEqual(blur_size(1050e6), 1100e6)
-        self.failUnlessEqual(blur_size(1100e6), 1100e6)
-        self.failUnlessEqual(blur_size(1150e6), 1200e6)
+        self.assertEqual(blur_size(0), 0)
+        self.assertEqual(blur_size(1), 10e3)
+        self.assertEqual(blur_size(10e3), 10e3)
+        self.assertEqual(blur_size(10e3+1), 20e3)
+        self.assertEqual(blur_size(15e3), 20e3)
+        self.assertEqual(blur_size(20e3), 20e3)
+        self.assertEqual(blur_size(1e6), 1e6)
+        self.assertEqual(blur_size(1e6+1), 2e6)
+        self.assertEqual(blur_size(1.5e6), 2e6)
+        self.assertEqual(blur_size(2e6), 2e6)
+        self.assertEqual(blur_size(900e6), 900e6)
+        self.assertEqual(blur_size(1000e6), 1000e6)
+        self.assertEqual(blur_size(1050e6), 1100e6)
+        self.assertEqual(blur_size(1100e6), 1100e6)
+        self.assertEqual(blur_size(1150e6), 1200e6)
 
     def test_register(self):
         p1 = self.new_protocol()
@@ -387,11 +387,11 @@ def _new_protocol_ws(transit_server, log_requests):
 
         def connectionMade(self):
             self.connected = True
-            return super(TransitWebSocketClientProtocol, self).connectionMade()
+            return super().connectionMade()
 
         def connectionLost(self, reason):
             self.connected = False
-            return super(TransitWebSocketClientProtocol, self).connectionLost(reason)
+            return super().connectionLost(reason)
 
         def onMessage(self, data, isBinary):
             self._received = self._received + data
@@ -503,7 +503,7 @@ class Usage(ServerBase, unittest.TestCase):
     log_requests = True
 
     def setUp(self):
-        super(Usage, self).setUp()
+        super().setUp()
         self._usage = MemoryUsageRecorder()
         self._transit_server.usage.add_backend(self._usage)
 
@@ -637,7 +637,7 @@ class UsageWebSockets(Usage):
     """
 
     def setUp(self):
-        super(UsageWebSockets, self).setUp()
+        super().setUp()
         self._pump = create_pumper()
         self._reactor = MemoryReactorClock()
         return self._pump.start()

--- a/src/wormhole_transit_relay/transit_server.py
+++ b/src/wormhole_transit_relay/transit_server.py
@@ -115,7 +115,7 @@ class TransitConnection(LineReceiver):
         self._state.connection_lost()
 
 
-class Transit(object):
+class Transit:
     """
     I manage pairs of simultaneous connections to a secondary TCP port,
     both forwarded to the other. Clients must begin each connection with
@@ -215,7 +215,7 @@ class WebSocketTransitConnection(WebSocketServerProtocol):
         """
         IProtocol API
         """
-        super(WebSocketTransitConnection, self).connectionMade()
+        super().connectionMade()
         self.started_time = time.time()
         self._first_message = True
         self._state = TransitServerState(

--- a/src/wormhole_transit_relay/usage.py
+++ b/src/wormhole_transit_relay/usage.py
@@ -124,7 +124,7 @@ class DatabaseUsageRecorder:
         self._db.commit()
 
 
-class UsageTracker(object):
+class UsageTracker:
     """
     Tracks usage statistics of connections
     """

--- a/update-version.py
+++ b/update-version.py
@@ -39,9 +39,9 @@ def create_new_version(git, only_patch):
     versions = existing_tags(git)
     major, minor, patch = sorted(versions)[-1]
     if only_patch:
-        next_version = "{}.{}.{}".format(major, minor, patch + 1)
+        next_version = f"{major}.{minor}.{patch + 1}"
     else:
-        next_version = "{}.{}.{}".format(major, minor + 1, 0)
+        next_version = f"{major}.{minor + 1}.{0}"
     return next_version
 
 
@@ -57,7 +57,7 @@ async def main(reactor):
 
     for arg in sys.argv[1:]:
         if arg not in ("--no-tag", "--patch"):
-            print("unknown arg: {}".format(arg))
+            print(f"unknown arg: {arg}")
             raise SystemExit(2)
 
     v = create_new_version(git, "--patch" in sys.argv)
@@ -66,7 +66,7 @@ async def main(reactor):
         return
 
     print("Latest version: {}.{}.{}".format(*sorted(existing_tags(git))[-1]))
-    print("New tag will be {}".format(v))
+    print(f"New tag will be {v}")
 
     # the "tag time" is seconds from the epoch .. we quantize these to
     # the start of the day in question, in UTC.
@@ -83,7 +83,7 @@ async def main(reactor):
         repo=git,
         tag=v.encode("utf8"),
         author=author.encode("utf8"),
-        message="release magic-wormhole-{}".format(v).encode("utf8"),
+        message=f"release magic-wormhole-{v}".encode("utf8"),
         annotated=True,
         objectish=b"HEAD",
         sign=author.encode("utf8"),
@@ -93,7 +93,7 @@ async def main(reactor):
 
     print("Tag created locally, it is not pushed")
     print("To push it run something like:")
-    print("   git push origin {}".format(v))
+    print(f"   git push origin {v}")
 
 
 if __name__ == "__main__":

--- a/versioneer.py
+++ b/versioneer.py
@@ -1,4 +1,3 @@
-
 # Version: 0.29
 
 """The Versioneer - like a rocketeer, but for versions.
@@ -400,7 +399,7 @@ def get_config_from_root(root: str) -> VersioneerConfig:
     root_pth = Path(root)
     pyproject_toml = root_pth / "pyproject.toml"
     setup_cfg = root_pth / "setup.cfg"
-    section: Union[Dict[str, Any], configparser.SectionProxy, None] = None
+    section: Union[dict[str, Any], configparser.SectionProxy, None] = None
     if pyproject_toml.exists() and have_tomllib:
         try:
             with open(pyproject_toml, 'rb') as fobj:
@@ -444,8 +443,8 @@ class NotThisMethod(Exception):
 
 
 # these dictionaries contain VCS-specific tools
-LONG_VERSION_PY: Dict[str, str] = {}
-HANDLERS: Dict[str, Dict[str, Callable]] = {}
+LONG_VERSION_PY: dict[str, str] = {}
+HANDLERS: dict[str, dict[str, Callable]] = {}
 
 
 def register_vcs_handler(vcs: str, method: str) -> Callable:  # decorator
@@ -458,18 +457,18 @@ def register_vcs_handler(vcs: str, method: str) -> Callable:  # decorator
 
 
 def run_command(
-    commands: List[str],
-    args: List[str],
+    commands: list[str],
+    args: list[str],
     cwd: Optional[str] = None,
     verbose: bool = False,
     hide_stderr: bool = False,
-    env: Optional[Dict[str, str]] = None,
-) -> Tuple[Optional[str], Optional[int]]:
+    env: Optional[dict[str, str]] = None,
+) -> tuple[Optional[str], Optional[int]]:
     """Call the given command(s)."""
     assert isinstance(commands, list)
     process = None
 
-    popen_kwargs: Dict[str, Any] = {}
+    popen_kwargs: dict[str, Any] = {}
     if sys.platform == "win32":
         # This hides the console window if pythonw.exe is used
         startupinfo = subprocess.STARTUPINFO()
@@ -494,7 +493,7 @@ def run_command(
             return None, None
     else:
         if verbose:
-            print("unable to find command, tried %s" % (commands,))
+            print("unable to find command, tried {}".format(commands))
         return None, None
     stdout = process.communicate()[0].strip().decode()
     if process.returncode != 0:
@@ -1192,15 +1191,15 @@ def get_versions() -> Dict[str, Any]:
 
 
 @register_vcs_handler("git", "get_keywords")
-def git_get_keywords(versionfile_abs: str) -> Dict[str, str]:
+def git_get_keywords(versionfile_abs: str) -> dict[str, str]:
     """Extract version information from the given file."""
     # the code embedded in _version.py can just fetch the value of these
     # keywords. When used from setup.py, we don't want to import _version.py,
     # so we do it with a regexp instead. This function is not used from
     # _version.py.
-    keywords: Dict[str, str] = {}
+    keywords: dict[str, str] = {}
     try:
-        with open(versionfile_abs, "r") as fobj:
+        with open(versionfile_abs) as fobj:
             for line in fobj:
                 if line.strip().startswith("git_refnames ="):
                     mo = re.search(r'=\s*"(.*)"', line)
@@ -1221,10 +1220,10 @@ def git_get_keywords(versionfile_abs: str) -> Dict[str, str]:
 
 @register_vcs_handler("git", "keywords")
 def git_versions_from_keywords(
-    keywords: Dict[str, str],
+    keywords: dict[str, str],
     tag_prefix: str,
     verbose: bool,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Get version information from git keywords."""
     if "refnames" not in keywords:
         raise NotThisMethod("Short version file found")
@@ -1293,7 +1292,7 @@ def git_pieces_from_vcs(
     root: str,
     verbose: bool,
     runner: Callable = run_command
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Get version from 'git describe' in the root of the source tree.
 
     This only gets called if the git-archive 'subst' keywords were *not*
@@ -1333,7 +1332,7 @@ def git_pieces_from_vcs(
         raise NotThisMethod("'git rev-parse' failed")
     full_out = full_out.strip()
 
-    pieces: Dict[str, Any] = {}
+    pieces: dict[str, Any] = {}
     pieces["long"] = full_out
     pieces["short"] = full_out[:7]  # maybe improved later
     pieces["error"] = None
@@ -1448,7 +1447,7 @@ def do_vcs_install(versionfile_source: str, ipy: Optional[str]) -> None:
         files.append(versioneer_file)
     present = False
     try:
-        with open(".gitattributes", "r") as fobj:
+        with open(".gitattributes") as fobj:
             for line in fobj:
                 if line.strip().startswith(versionfile_source):
                     if "export-subst" in line.strip().split()[1:]:
@@ -1467,7 +1466,7 @@ def versions_from_parentdir(
     parentdir_prefix: str,
     root: str,
     verbose: bool,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Try to determine the version from the parent directory name.
 
     Source tarballs conventionally unpack into a directory that includes both
@@ -1509,7 +1508,7 @@ def get_versions():
 """
 
 
-def versions_from_file(filename: str) -> Dict[str, Any]:
+def versions_from_file(filename: str) -> dict[str, Any]:
     """Try to determine the version from _version.py if present."""
     try:
         with open(filename) as f:
@@ -1526,24 +1525,24 @@ def versions_from_file(filename: str) -> Dict[str, Any]:
     return json.loads(mo.group(1))
 
 
-def write_to_version_file(filename: str, versions: Dict[str, Any]) -> None:
+def write_to_version_file(filename: str, versions: dict[str, Any]) -> None:
     """Write the given version number to the given _version.py file."""
     contents = json.dumps(versions, sort_keys=True,
                           indent=1, separators=(",", ": "))
     with open(filename, "w") as f:
         f.write(SHORT_VERSION_PY % contents)
 
-    print("set %s to '%s'" % (filename, versions["version"]))
+    print("set {} to '{}'".format(filename, versions["version"]))
 
 
-def plus_or_dot(pieces: Dict[str, Any]) -> str:
+def plus_or_dot(pieces: dict[str, Any]) -> str:
     """Return a + if we don't already have one, else return a ."""
     if "+" in pieces.get("closest-tag", ""):
         return "."
     return "+"
 
 
-def render_pep440(pieces: Dict[str, Any]) -> str:
+def render_pep440(pieces: dict[str, Any]) -> str:
     """Build up version string, with post-release "local version identifier".
 
     Our goal: TAG[+DISTANCE.gHEX[.dirty]] . Note that if you
@@ -1568,7 +1567,7 @@ def render_pep440(pieces: Dict[str, Any]) -> str:
     return rendered
 
 
-def render_pep440_branch(pieces: Dict[str, Any]) -> str:
+def render_pep440_branch(pieces: dict[str, Any]) -> str:
     """TAG[[.dev0]+DISTANCE.gHEX[.dirty]] .
 
     The ".dev0" means not master branch. Note that .dev0 sorts backwards
@@ -1598,7 +1597,7 @@ def render_pep440_branch(pieces: Dict[str, Any]) -> str:
     return rendered
 
 
-def pep440_split_post(ver: str) -> Tuple[str, Optional[int]]:
+def pep440_split_post(ver: str) -> tuple[str, Optional[int]]:
     """Split pep440 version string at the post-release segment.
 
     Returns the release segments before the post-release and the
@@ -1608,7 +1607,7 @@ def pep440_split_post(ver: str) -> Tuple[str, Optional[int]]:
     return vc[0], int(vc[1] or 0) if len(vc) == 2 else None
 
 
-def render_pep440_pre(pieces: Dict[str, Any]) -> str:
+def render_pep440_pre(pieces: dict[str, Any]) -> str:
     """TAG[.postN.devDISTANCE] -- No -dirty.
 
     Exceptions:
@@ -1632,7 +1631,7 @@ def render_pep440_pre(pieces: Dict[str, Any]) -> str:
     return rendered
 
 
-def render_pep440_post(pieces: Dict[str, Any]) -> str:
+def render_pep440_post(pieces: dict[str, Any]) -> str:
     """TAG[.postDISTANCE[.dev0]+gHEX] .
 
     The ".dev0" means dirty. Note that .dev0 sorts backwards
@@ -1659,7 +1658,7 @@ def render_pep440_post(pieces: Dict[str, Any]) -> str:
     return rendered
 
 
-def render_pep440_post_branch(pieces: Dict[str, Any]) -> str:
+def render_pep440_post_branch(pieces: dict[str, Any]) -> str:
     """TAG[.postDISTANCE[.dev0]+gHEX[.dirty]] .
 
     The ".dev0" means not master branch.
@@ -1688,7 +1687,7 @@ def render_pep440_post_branch(pieces: Dict[str, Any]) -> str:
     return rendered
 
 
-def render_pep440_old(pieces: Dict[str, Any]) -> str:
+def render_pep440_old(pieces: dict[str, Any]) -> str:
     """TAG[.postDISTANCE[.dev0]] .
 
     The ".dev0" means dirty.
@@ -1710,7 +1709,7 @@ def render_pep440_old(pieces: Dict[str, Any]) -> str:
     return rendered
 
 
-def render_git_describe(pieces: Dict[str, Any]) -> str:
+def render_git_describe(pieces: dict[str, Any]) -> str:
     """TAG[-DISTANCE-gHEX][-dirty].
 
     Like 'git describe --tags --dirty --always'.
@@ -1730,7 +1729,7 @@ def render_git_describe(pieces: Dict[str, Any]) -> str:
     return rendered
 
 
-def render_git_describe_long(pieces: Dict[str, Any]) -> str:
+def render_git_describe_long(pieces: dict[str, Any]) -> str:
     """TAG-DISTANCE-gHEX[-dirty].
 
     Like 'git describe --tags --dirty --always -long'.
@@ -1750,7 +1749,7 @@ def render_git_describe_long(pieces: Dict[str, Any]) -> str:
     return rendered
 
 
-def render(pieces: Dict[str, Any], style: str) -> Dict[str, Any]:
+def render(pieces: dict[str, Any], style: str) -> dict[str, Any]:
     """Render the given version pieces into the requested style."""
     if pieces["error"]:
         return {"version": "unknown",
@@ -1790,7 +1789,7 @@ class VersioneerBadRootError(Exception):
     """The project root directory is unknown or missing key files."""
 
 
-def get_versions(verbose: bool = False) -> Dict[str, Any]:
+def get_versions(verbose: bool = False) -> dict[str, Any]:
     """Get the project version from whatever source is available.
 
     Returns dict with two keys: 'version' and 'full'.
@@ -1833,7 +1832,7 @@ def get_versions(verbose: bool = False) -> Dict[str, Any]:
     try:
         ver = versions_from_file(versionfile_abs)
         if verbose:
-            print("got version from file %s %s" % (versionfile_abs, ver))
+            print("got version from file {} {}".format(versionfile_abs, ver))
         return ver
     except NotThisMethod:
         pass
@@ -1871,7 +1870,7 @@ def get_version() -> str:
     return get_versions()["version"]
 
 
-def get_cmdclass(cmdclass: Optional[Dict[str, Any]] = None):
+def get_cmdclass(cmdclass: Optional[dict[str, Any]] = None):
     """Get the custom setuptools subclasses used by Versioneer.
 
     If the package uses a different cmdclass (e.g. one from numpy), it
@@ -1899,8 +1898,8 @@ def get_cmdclass(cmdclass: Optional[Dict[str, Any]] = None):
 
     class cmd_version(Command):
         description = "report generated version string"
-        user_options: List[Tuple[str, str, str]] = []
-        boolean_options: List[str] = []
+        user_options: list[tuple[str, str, str]] = []
+        boolean_options: list[str] = []
 
         def initialize_options(self) -> None:
             pass
@@ -2105,7 +2104,7 @@ def get_cmdclass(cmdclass: Optional[Dict[str, Any]] = None):
             self.distribution.metadata.version = versions["version"]
             return _sdist.run(self)
 
-        def make_release_tree(self, base_dir: str, files: List[str]) -> None:
+        def make_release_tree(self, base_dir: str, files: list[str]) -> None:
             root = get_root()
             cfg = get_config_from_root(root)
             _sdist.make_release_tree(self, base_dir, files)
@@ -2200,7 +2199,7 @@ def do_setup() -> int:
     maybe_ipy: Optional[str] = ipy
     if os.path.exists(ipy):
         try:
-            with open(ipy, "r") as f:
+            with open(ipy) as f:
                 old = f.read()
         except OSError:
             old = ""
@@ -2232,7 +2231,7 @@ def scan_setup_py() -> int:
     found = set()
     setters = False
     errors = 0
-    with open("setup.py", "r") as f:
+    with open("setup.py") as f:
         for line in f.readlines():
             if "import versioneer" in line:
                 found.add("import")

--- a/ws_client.py
+++ b/ws_client.py
@@ -35,7 +35,7 @@ class RelayEchoClient(WebSocketClientProtocol):
         )
 
     def onMessage(self, data, isBinary):
-        print(">onMessage: {} bytes".format(len(data)))
+        print(f">onMessage: {len(data)} bytes")
         print(data, isBinary)
         if data == b"ok\n":
             self.factory.ready.callback(None)
@@ -78,5 +78,5 @@ def main(reactor):
         yield proto.sendClose()
         print("closing")
     yield f.done
-    print("relayed {} bytes:".format(len(proto._received)))
+    print(f"relayed {len(proto._received)} bytes:")
     print(proto._received.decode("utf8"))


### PR DESCRIPTION
The update has been done with:
`pyup-dirs --py39-plus --recursive .`

(`pyup-dirs` is a `pyupgrade` wrapper for directories.)

Then some unused imports have been removed (because the uses have been removed previously by `pyup-dirs` command).

Tox is green after the changes (tested with python 3.13).